### PR TITLE
Unlock scrolling when input fd is closed.

### DIFF
--- a/ch.c
+++ b/ch.c
@@ -19,6 +19,8 @@ extern dev_t curr_dev;
 extern ino_t curr_ino;
 #endif
 
+#include <poll.h>
+
 typedef POSITION BLOCKNUM;
 
 public int ignore_eoi;
@@ -294,6 +296,14 @@ ch_get(VOID_PARAM)
 		ch_fsize = pos;
 		if (ignore_eoi)
 		{
+			struct pollfd poller = { ch_file, 0, 0 };
+			poll(&poller, 1, 0);
+			if ((poller.revents & POLLERR) || (poller.revents & POLLHUP))
+			{
+				sigs |= S_INTERRUPT;
+				return (EOI);
+			}
+
 			/*
 			 * We are ignoring EOF.
 			 * Wait a while, then try again.


### PR DESCRIPTION
As per our discussion, here's a PR so we can discuss more easily.
If you can point me to an easy way to test this change on other platforms, I'd be happy to help.

Please also consider the alternative option I suggested: when in follow mode and an arrow key is pressed, `less` could simply leave the follow mode (right now I can achieve this by pressing `Ctrl + Z` and then `fg`). No need for `select`/`poll` in that case.