### PR TITLE
Make sure public functions parameters are unaffected by argument promotion

### DIFF
--- a/charset.c
+++ b/charset.c
@@ -502,7 +502,7 @@ prutfchar(ch)
  */
 	public int
 utf_len(ch)
-	unsigned char ch;
+	int ch;
 {
 	if ((ch & 0x80) == 0)
 		return 1;

--- a/line.c
+++ b/line.c
@@ -787,7 +787,7 @@ flush_mbc_buf(pos)
  */
 	public int
 pappend(c, pos)
-	unsigned char c;
+	int c;
 	POSITION pos;
 {
 	int r;
@@ -1157,7 +1157,7 @@ pdone(endline, chopped, forw)
  */
 	public void
 set_status_col(c)
-	char c;
+	int c;
 {
 	set_linebuf(0, c, AT_NORMAL|AT_HILITE);
 }


### PR DESCRIPTION
In order for a prototype declaration and non-prototype function
definition to be compatible, the promoted type of the non-prototype
function parameters must be compatible with the type of the corresponding
prototype parameter.

Since funcs.h is autogenerated by mkfuncs.pl which copies the parameter
types as-is, use the promoted type in the definitions so that the types
are unaffected by default argument promotion.

Fixes #11