### PR TITLE
Remove `;` after function definition

### DIFF
--- a/output.c
+++ b/output.c
@@ -493,8 +493,8 @@ type funcname(buf, ebuf) \
 	return val; \
 }
 
-STR_TO_TYPE_FUNC(lstrtopos, POSITION);
-STR_TO_TYPE_FUNC(lstrtoi, int);
+STR_TO_TYPE_FUNC(lstrtopos, POSITION)
+STR_TO_TYPE_FUNC(lstrtoi, int)
 
 /*
  * Output an integer in a given radix.


### PR DESCRIPTION
The `STR_TO_TYPE_FUNC` macro expands to a function definition, so the `;`
is treated as an empty top-level declaration, which is not valid in ISO C.