### PR TITLE
Correct description of -S

### DIFF
--- a/less.nro.VER
+++ b/less.nro.VER
@@ -801,10 +801,8 @@ This is useful when viewing
 .I nroff
 output.
 .IP "\-S or \-\-chop-long-lines"
-Causes lines longer than the screen width to be
-chopped (truncated) rather than wrapped.
-That is, the portion of a long line that does not fit in
-the screen width is not shown.
+Display only the beginning of lines that exceed the screen width.
+The remainder can be shown by scrolling horizontally.
 The default is to wrap long lines; that is, display the remainder
 on the next line.
 .IP "\-t\fItag\fP or \-\-tag=\fItag\fP"


### PR DESCRIPTION
Lines are not truncated with -S, diff here matches change applied in OpenBSD by Ingo Schwarze.

https://marc.info/?l=openbsd-tech&m=156362993300918&w=2