### PR TITLE
Prevent double free of namelogfile

### DIFF
--- a/edit.c
+++ b/edit.c
@@ -847,7 +847,6 @@ loop:
 		/*
 		 * Don't do anything.
 		 */
-		free(filename);
 		return;
 	case 'q':
 		quit(QUIT_OK);


### PR DESCRIPTION
In certain circumstances [1] less crashes because it tries to
double-free memory allocated at 'namelogfile'. Prevent this by setting
'namelogfile' to NULL after each free.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1770901