### PR TITLE
Fix special character bindings not working when loaded with -k

### DIFF
--- a/main.c
+++ b/main.c
@@ -110,7 +110,6 @@ main(argc, argv)
 	init_mark();
 	init_cmds();
 	get_term();
-	expand_cmd_tables();
 	init_charset();
 	init_line();
 	init_cmdhist();
@@ -151,6 +150,8 @@ main(argc, argv)
 		nopendopt();
 		quit(QUIT_OK);
 	}
+
+	expand_cmd_tables();
 
 #if EDITOR
 	editor = lgetenv("VISUAL");


### PR DESCRIPTION
Since the `-k` option may cause additional command tables to be loaded, `expand_cmd_tables` must be called after options are processed. Otherwise, any bindings involving special characters will not be functional.