### PR TITLE
Apply OSC 8 hyperlinks patch

### DIFF
--- a/charset.c
+++ b/charset.c
@@ -426,6 +426,7 @@ control_char(c)
 	LWCHAR c;
 {
 	c &= 0377;
+	if (c == 7) return FALSE;  /* FIXME hack for OSC 8, should be shown as ^G if outside of this escape sequence */
 	return (chardef[c] & IS_CONTROL_CHAR);
 }
 

--- a/cvt.c
+++ b/cvt.c
@@ -78,13 +78,32 @@ cvt_text(odst, osrc, chpos, lenp, ops)
 				dst--;
 			} while (dst > odst && utf_mode &&
 				!IS_ASCII_OCTET(*dst) && !IS_UTF8_LEAD(*dst));
-		} else if ((ops & CVT_ANSI) && IS_CSI_START(ch))
+		} else if ((ops & CVT_ANSI) && ch == ESC)
 		{
-			/* Skip to end of ANSI escape sequence. */
-			src++;  /* skip the CSI start char */
-			while (src < src_end)
-				if (!is_ansi_middle(*src++))
-					break;
+            if (src[0] == ']' && src[1] == '8' && src[2] == ';')
+            {
+                /* Skip to the end of a hyperlink. */
+                src += 3;
+                while (src < src_end)
+                {
+                    if (src[0] == BEL)
+                    {
+                        src++;
+                        break;
+                    } else if (src[0] == ESC && src[1] == '\\')
+                    {
+                        src += 2;
+                        break;
+                    }
+                    src++;
+                }
+            } else
+            {
+                /* Skip to end of ANSI escape sequence. */
+                while (src < src_end)
+                    if (!is_ansi_middle(*src++))
+                        break;
+            }
 		} else
 		{
 			/* Just copy the char to the destination buffer. */

--- a/less.h
+++ b/less.h
@@ -456,7 +456,10 @@ struct wchar_range_table
 
 #define	ESC		CONTROL('[')
 #define	ESCS		"\33"
+#define	BEL		CONTROL('g')
 #define	CSI		((unsigned char)'\233')
+#define ST      ((unsigned char)'\234')
+#define OSC     ((unsigned char)'\235')
 #define	CHAR_END_COMMAND 0x40000000
 
 #if _OSK_MWC32


### PR DESCRIPTION
Ref https://github.com/gwsw/less/issues/54

In case it is useful, this PR applies the OSC hyperlinks patch from https://bug779734.bugzilla-attachments.gnome.org/attachment.cgi?id=349890 on top of master. (Some minor edits were required to make the patch apply.)

I am using less built from this commit, and can confirm that hyperlinks are passed on correctly and that I have not observed any problems with less while using it so far. However, I am not familiar with the less code base and I am not sure how to test thoroughly. Please feel free to close this PR if it is just creating noise.

