### PR TITLE
Add wrap-around search modifier

### DIFF
--- a/command.c
+++ b/command.c
@@ -168,6 +168,8 @@ mca_search(VOID_PARAM)
 		cmd_putstr("Keep-pos ");
 	if (search_type & SRCH_NO_REGEX)
 		cmd_putstr("Regex-off ");
+	if (search_type & SRCH_WRAP_AROUND)
+		cmd_putstr("Wrap-around ");
 
 #if HILITE_SEARCH
 	if (search_type & SRCH_FILTER)
@@ -534,6 +536,10 @@ mca_search_char(c)
 		if (mca != A_FILTER)
 			flag = SRCH_NO_MOVE;
 		break;
+	case CONTROL('W'): /* WRAP around */
+		if (mca != A_FILTER)
+			flag = SRCH_WRAP_AROUND;
+		break;
 	case CONTROL('R'): /* Don't use REGULAR EXPRESSIONS */
 		flag = SRCH_NO_REGEX;
 		break;
@@ -545,7 +551,8 @@ mca_search_char(c)
 
 	if (flag != 0)
 	{
-		search_type ^= flag;
+		/* Toggle flag, but keep PAST_EOF and WRAP_AROUND mutually exclusive. */
+		search_type ^= flag | (search_type & (SRCH_PAST_EOF|SRCH_WRAP_AROUND));
 		mca_search();
 		return (MCA_MORE);
 	}

--- a/less.h
+++ b/less.h
@@ -355,6 +355,7 @@ struct wchar_range_table
 #define SRCH_NO_REGEX   (1 << 12) /* Don't use regular expressions */
 #define SRCH_FILTER     (1 << 13) /* Search is for '&' (filter) command */
 #define SRCH_AFTER_TARGET (1 << 14) /* Start search after the target line */
+#define SRCH_WRAP_AROUND (1 << 15) /* Wrap-around search (continue at BOF/EOF) */
 
 #define	SRCH_REVERSE(t)	(((t) & SRCH_FORW) ? \
 				(((t) & ~SRCH_FORW) | SRCH_BACK) : \

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -226,6 +226,11 @@ but don't move to the first match (KEEP current position).
 .IP "^R"
 Don't interpret regular expression metacharacters;
 that is, do a simple textual comparison.
+.IP "^W"
+WRAP around the current file.
+That is, if the search reaches the end of the current file
+without finding a match, the search continues from the first line of the
+current file up to the line where it started.
 .RE
 .IP ?pattern
 Search backward in the file for the N-th line containing the pattern.
@@ -250,6 +255,11 @@ or the settings of the \-a or \-j options.
 As in forward searches.
 .IP "^R"
 As in forward searches.
+.IP "^W"
+WRAP around the current file.
+That is, if the search reaches the beginning of the current file
+without finding a match, the search continues from the last line of the
+current file up to the line where it started.
 .RE
 .IP "ESC-/pattern"
 Same as "/*".

--- a/search.c
+++ b/search.c
@@ -1174,6 +1174,9 @@ search_range(pos, endpos, search_type, matches, maxlines, plinepos, pendpos)
 
 	linenum = find_linenum(pos);
 	oldpos = pos;
+	/* When the search wraps around, end at starting position. */
+        if ((search_type & SRCH_WRAP_AROUND) && endpos == NULL_POSITION)
+		endpos = pos;
 	for (;;)
 	{
 		/*
@@ -1189,7 +1192,9 @@ search_range(pos, endpos, search_type, matches, maxlines, plinepos, pendpos)
 			return (-1);
 		}
 
-		if ((endpos != NULL_POSITION && pos >= endpos) || maxlines == 0)
+		if ((endpos != NULL_POSITION && !(search_type & SRCH_WRAP_AROUND) &&
+			(((search_type & SRCH_FORW) && pos >= endpos) ||
+			 ((search_type & SRCH_BACK) && pos <= endpos))) || maxlines == 0)
 		{
 			/*
 			 * Reached end position without a match.
@@ -1228,6 +1233,35 @@ search_range(pos, endpos, search_type, matches, maxlines, plinepos, pendpos)
 			/*
 			 * Reached EOF/BOF without a match.
 			 */
+			if (search_type & SRCH_WRAP_AROUND)
+			{
+				/*
+				 * The search wraps around the current file, so
+				 * try to continue at BOF/EOF.
+				 */
+				if (search_type & SRCH_FORW)
+				{
+					pos = ch_zero();
+				} else
+				{
+					pos = ch_length();
+					if (pos == NULL_POSITION)
+					{
+						(void) ch_end_seek();
+						pos = ch_length();
+					}
+				}
+				if (pos != NULL_POSITION) {
+					/*
+					 * Wrap-around was successful. Clear
+					 * the flag so we don't wrap again, and
+					 * continue the search at new pos.
+					 */
+					search_type &= ~SRCH_WRAP_AROUND;
+					linenum = find_linenum(pos);
+					continue;
+				}
+			}
 			if (pendpos != NULL)
 				*pendpos = oldpos;
 			return (matches);


### PR DESCRIPTION
This PR implements wrap-around search for the current file.

With the added `^W` search modifier in use, a forward search doesn't end at EOF, but continues from the beginning of the current file up until the searches' starting point. A backward search does the reverse.

Rationale: Wrap-around is a common search feature that has been [sought for in less in the past](https://unix.stackexchange.com/questions/255862/search-in-less-with-wrap-around-at-eof). It allows the user to use the same key (`n`/`N`) to infinitely loop through the search results, without having to consider that they may have already gone past a match. The feature is limited to the current file because the added complexity seems reasonable. It looks to me like wrap-around across multiple files would come with some gotchas and be less straightforward.