### PR TITLE
Multiple &-filters can now be in effect at the same time.

### DIFF
--- a/command.c
+++ b/command.c
@@ -780,8 +780,15 @@ prompt(VOID_PARAM)
 	clear_cmd();
 	forw_prompt = 0;
 	p = pr_string();
-	if (is_filtering())
-		putstr("& ");
+	switch (is_filtering()) {
+		case 0:
+			break;
+		case 1:
+			putstr("& ");
+			break;
+		default:
+			putstr("&* ");
+	}
 	if (p == NULL || *p == '\0')
 		putchr(':');
 	else

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -288,6 +288,9 @@ any filtering is turned off, and all lines are displayed.
 While filtering is in effect, an ampersand is displayed at the
 beginning of the prompt,
 as a reminder that some lines in the file may be hidden.
+If you add more than one filter pattern, only lines that pass all
+filters will be displayed. If more than one filter is in effect,
+the prompt will display an asterisk next to the ampersand.
 .sp
 Certain characters are special as in the / command:
 .RS


### PR DESCRIPTION
A common use case for me is that I want to filter some "spammy lines" out while reading log files, but more often than not next category of spammy lines emerges just after the first filter is applied. In these cases I might try to update the filter pattern to cover both line patterns, which might be non-trivial — for example if the individual patterns is using a mix of ^R and ^N. (In reality, I tend to just quit less and pre-filter the log file instead). The change in this pull request saves me from doing most of those context switches — and I figured that someone else might have the same problem.