### PR TITLE
Use ttyname() instead of hardwired "/dev/tty".

### DIFF
--- a/lsystem.c
+++ b/lsystem.c
@@ -110,10 +110,10 @@ lsystem(cmd, donemsg)
 	inp = dup(0);
 	close(0);
 #if OS2
-	/* The __open() system call translates "/dev/tty" to "con". */
-	if (__open("/dev/tty", OPEN_READ) < 0)
+	/* The __open() system call translates ttyname (0) to "con". */
+	if (__open(ttyname (0), OPEN_READ) < 0)
 #else
-	if (open("/dev/tty", OPEN_READ) < 0)
+	if (open(ttyname (0), OPEN_READ) < 0)
 #endif
 		dup(inp);
 #endif

--- a/ttyin.c
+++ b/ttyin.c
@@ -69,9 +69,9 @@ open_getchr(VOID_PARAM)
 	 */
 #if OS2
 	/* The __open() system call translates "/dev/tty" to "con". */
-	tty = __open("/dev/tty", OPEN_READ);
+	tty = __open(ttyname (0), OPEN_READ);
 #else
-	tty = open("/dev/tty", OPEN_READ);
+	tty = open(ttyname (0), OPEN_READ);
 #endif
 	if (tty < 0)
 		tty = 2;


### PR DESCRIPTION
My system has trouble using /dev/tty as the terminal.  Please consider applying this patch which fixes the problem for me, and probably will for some others, too.