### PR TITLE
fix too many arguments warning

### DIFF
--- a/search.c
+++ b/search.c
@@ -1829,7 +1829,7 @@ prep_hilite(spos, epos, maxlines)
 		search_type |= (search_info.search_type & SRCH_NO_REGEX);
 		for (;;) 
 		{
-			result = search_range(spos, epos, search_type, 0, maxlines, (POSITION*)NULL, &new_epos, (POSITION*)NULL, (POSITION*)NULL);
+			result = search_range(spos, epos, search_type, 0, maxlines, (POSITION*)NULL, &new_epos, (POSITION*)NULL);
 			if (result < 0)
 				return;
 			if (prep_endpos == NULL_POSITION || new_epos > prep_endpos)


### PR DESCRIPTION
This fixes the following warning when running `make -f Makefile.aut && sh configure && make`:

```
> gcc -I. -c -DBINDIR=\"/usr/local/bin\" -DSYSDIR=\"/usr/local/etc\"  -g -O2 search.c
> search.c:1832:124: warning: too many arguments in call to 'search_range'
>                         result = search_range(spos, epos, search_type, 0, maxlines, (POSITION*)NULL, &new_epos, (POSITION*)NULL, (POSITION*)NULL);
>                                  ~~~~~~~~~~~~                                                                                                   ^
> 1 warning generated.
```