### PR TITLE
Fix ANSI skipping

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -481,8 +481,10 @@ bin_file(f)
 			LWCHAR c = step_char(&p, +1, edata);
 			struct ansi_state *pansi;
 			if (ctldisp == OPT_ONPLUS && (pansi = ansi_start(c)) != NULL)
+			{
 				skip_ansi(pansi, &p, edata);
-			else if (binary_char(c))
+				ansi_done(pansi);
+			} else if (binary_char(c))
 				bin_count++;
 		}
 	}

--- a/line.c
+++ b/line.c
@@ -569,7 +569,7 @@ skip_ansi(pansi, pp, limit)
 	LWCHAR c;
 	do {
 		c = step_char(pp, +1, limit);
-	} while (*pp < limit && ansi_step(pansi, c) != ANSI_MID);
+	} while (*pp < limit && ansi_step(pansi, c) == ANSI_MID);
 	/* Note that we discard final char, for which is_ansi_end is true. */
 }
 
@@ -614,10 +614,10 @@ ansi_step(pansi, ch)
 	if (pansi->hindex >= 0)
 	{
 		static char hlink_prefix[] = ESCS "]8;";
-		if (ch == hlink_prefix[pansi->hindex++] ||
+		if (ch == hlink_prefix[pansi->hindex] ||
 		    (pansi->hindex == 0 && IS_CSI_START(ch)))
 		{
-			if (hlink_prefix[pansi->hindex] == '\0')
+			if (hlink_prefix[++pansi->hindex] == '\0')
 				pansi->hlink = 1; /* now processing hyperlink addr */
 			return ANSI_MID;
 		}
@@ -961,6 +961,8 @@ store_ansi(ch, rep, pos)
 			bch = step_char(&p, -1, linebuf.buf);
 		} while (p > linebuf.buf && !IS_CSI_START(bch));
 		linebuf.end = (int) (p - linebuf.buf);
+		ansi_done(line_ansi);
+		line_ansi = NULL;
 		break; }
 	}
 	return (0);


### PR DESCRIPTION
 - Add a missing `ansi_done` to `bin_file` to free `pansi`.
 - Fix the inverted loop condition in `skip_ansi` so it actually skips.
 - Fix a condition in `step_ansi`: `pansi->hindex == 0` was never true.
 - Fix the sequence removal in `store_ansi` to reset the `line_ansi`.

Fixes https://github.com/gwsw/less/issues/140