### PR TITLE
Fix "Tag not found" error while looking for a tag's location

### DIFF
--- a/tags.c
+++ b/tags.c
@@ -265,6 +265,7 @@ findctag(tag)
 	char *tag;
 {
 	char *p;
+	char *q;
 	FILE *f;
 	int taglen;
 	LINENUM taglinenum;
@@ -345,17 +346,24 @@ findctag(tag)
 			search_char = *p++;
 			if (*p == '^')
 				p++;
-			tagpattern = p;
+			tagpattern = q = p;
 			while (*p != search_char && *p != '\0')
 			{
 				if (*p == '\\')
 					p++;
-				p++;
+					if (q != p)
+					{
+						*q++ = *p++;
+					} else
+					{
+						q++;
+						p++;
+					}
 			}
-			tagendline = (p[-1] == '$');
+			tagendline = (q[-1] == '$');
 			if (tagendline)
-				p--;
-			*p = '\0';
+				q--;
+			*q = '\0';
 		}
 		tp = maketagent(tag, tagfile, taglinenum, tagpattern, tagendline);
 		TAG_INS(tp);


### PR DESCRIPTION
In findctag() restore code to actually remove '\' from the pattern
buffer. The comment in the function says it is removing backslashes,
but that code was removed during edits around 12/11/2001.  This fix
restores the original code except that it avoids copying characters
on top of themselves.  Instead, it only begins to copy characters
after encountering a backslash.