### PR TITLE
Fix minor memory leak with input preprocessor.

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -946,10 +946,13 @@ open_altfile(filename, pf, pfd)
 	cmd = readfd(fd);
 	pclose(fd);
 	if (*cmd == '\0')
+	{
 		/*
 		 * Pipe is empty.  This means there is no alt file.
 		 */
+		free(cmd);
 		return (NULL);
+	}
 	return (cmd);
 #endif /* HAVE_POPEN */
 }


### PR DESCRIPTION
When opening a file, if the command in LESSOPEN does not produce an output, readfd still returns an allocated buffer, which is then leaked by open_altfile.

```
$ LESSOPEN="/bin/false %s" valgrind --leak-check=full less somefile
==68737== Memcheck, a memory error detector
==68737== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==68737== Using Valgrind-3.16.1 and LibVEX; rerun with -h for copyright info
==68737== Command: less somefile
==68737== 
==68737== 
==68737== HEAP SUMMARY:
==68737==     in use at exit: 26,445 bytes in 146 blocks
==68737==   total heap usage: 221 allocs, 75 frees, 94,076 bytes allocated
==68737== 
==68737== 100 bytes in 1 blocks are definitely lost in loss record 23 of 38
==68737==    at 0x483ED99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==68737==    by 0x10CF31: ecalloc (main.c:317)
==68737==    by 0x116C55: readfd (filename.c:535)
==68737==    by 0x117A26: open_altfile (filename.c:946)
==68737==    by 0x1164B4: edit_ifile.part.0 (edit.c:323)
==68737==    by 0x11680C: edit_ifile (edit.c:254)
==68737==    by 0x11680C: edit_istep (edit.c:616)
==68737==    by 0x10CC26: main (main.c:268)
==68737== 
==68737== LEAK SUMMARY:
==68737==    definitely lost: 100 bytes in 1 blocks
==68737==    indirectly lost: 0 bytes in 0 blocks
==68737==      possibly lost: 0 bytes in 0 blocks
==68737==    still reachable: 26,345 bytes in 145 blocks
==68737==         suppressed: 0 bytes in 0 blocks
==68737== Reachable blocks (those to which a pointer was found) are not shown.
==68737== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==68737== 
==68737== For lists of detected and suppressed errors, rerun with: -s
==68737== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)

```