### PR TITLE
Fix crash due to memcpy with overlapping objects

### DIFF
--- a/line.c
+++ b/line.c
@@ -740,8 +740,8 @@ store_char(ch, a, rep, pos)
 		if (linebuf.end > linebuf.print)
 		{
 			/* Shift left enough to put last byte of this char at print-1. */
-			memcpy(&linebuf.buf[0], &linebuf.buf[replen], linebuf.print);
-			memcpy(&linebuf.attr[0], &linebuf.attr[replen], linebuf.print);
+			memmove(&linebuf.buf[0], &linebuf.buf[replen], linebuf.print);
+			memmove(&linebuf.attr[0], &linebuf.attr[replen], linebuf.print);
 			linebuf.end -= replen;
 			cshift += w;
 			/*


### PR DESCRIPTION
According to the POSIX specification of `memcpy(3)`. If a copy takes place between objects that overlap, the behaviour is undefined. Unfortunately, the horizontal scrolling implementation in less contained two such `memcpy` invocations which lead to crash on Alpine Linux. Since The `_FORTIFY_SOURCE` implementation used on Alpine Linux, checks for `memcpy` invocations with overlapping objects and crashes the program when such an invocation is found. On Alpine this crash can be reproduced by opening a file which exceeds the terminal width in the horizontal dimension and then attempting to scroll horizontally. The core dump looks as follows:

```
#0  memcpy (__n=<optimized out>, __os=<optimized out>, __od=<optimized out>) at /usr/include/fortify/string.h:50
#1  store_char (ch=101, a=<optimized out>, rep=<optimized out>, pos=<optimized out>) at line.c:743
#2  0x0000561d06cf3d17 in do_append (pos=<optimized out>, rep=<optimized out>, ch=<optimized out>) at line.c:1095
#3  do_append (ch=<optimized out>, rep=<optimized out>, pos=0) at line.c:994
#4  0x0000561d06cf3e27 in pappend (c=c@entry=101, pos=0) at line.c:884
#5  0x0000561d06cf1b5e in forw_line_seg (curr_pos=<optimized out>, curr_pos@entry=0, get_segpos=get_segpos@entry=0) at input.c:170
#6  0x0000561d06cf1caf in forw_line (curr_pos=curr_pos@entry=0) at input.c:257
#7  0x0000561d06cf13ac in forw (n=64, pos=0, force=force@entry=1, only_last=only_last@entry=0, nblank=0) at forwback.c:215
#8  0x0000561d06cf20ae in jump_loc (pos=<optimized out>, sline=<optimized out>) at jump.c:279
#9  0x0000561d06cf2267 in repaint () at jump.c:124
#10 0x0000561d06ced10f in make_display () at command.c:743
#11 make_display () at command.c:719
#12 0x0000561d06ced89e in prompt () at command.c:769
#13 commands () at command.c:1216
#14 0x0000561d06ce8826 in main (argc=-1, argv=0x7fff48edfcf8) at main.c:296
```

The fact that this is indeed an overlapping `memcpy(3)` invocation can be easily confirmed using gdb:

```
gdb --args ./less /tmp/log
(gdb) break line.c:743
(gdb) run
<scroll horizontally>
743				memcpy(&linebuf.buf[0], &linebuf.buf[replen], linebuf.print);
(gdb) p replen
1
(gdb) p linebuf.print
6
```

Copying 6 bytes from `&linebuf.buf[0]` to `&linebuf.buf[1]` overlaps obviously.

This commit fixes this issue by using `memmove(3)` instead of `memcpy(3)`, thereby fixing a regression introduced in 143ba345 and d7f6d4ec.