### PR TITLE
exclude README and NEWS from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,6 @@ release/**
 *.o
 *.old
 Makefile
-NEWS
-README
 config.status
 configure
 defines.h


### PR DESCRIPTION
Now README and NEWS are no longer generated files as of commit c4ab73f.

Therefore removing them from .gitignore, otherwise we won't be able to find them with tools that understand ignore files.
