### PR TITLE
Add --repeat-search-skip-screen option.

### DIFF
--- a/less.hlp
+++ b/less.hlp
@@ -219,6 +219,8 @@
                   Don't send termcap keypad init/deinit strings.
                 --no-histdups
                   Remove duplicates from command history.
+                --repeat-search-skip-screen
+                  Repeated search (n/N) skips current screen.
                 --rscroll=C
                   Set the character used to mark truncated lines.
                 --save-marks

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -518,8 +518,9 @@ it may be necessary to quote the question mark, thus: "\-\e?".)
 By default, forward searches start at the top of the displayed screen
 and backwards searches start at the bottom of the displayed screen
 (except for repeated searches invoked by the n or N commands,
-which start after or before the "target" line respectively;
-see the \-j option for more about the target line).
+which by default start after or before the "target" line respectively;
+see the \-j option for more about the target line
+and \-\-repeat-search-skip-screen to modify this behavior).
 The \-a option causes forward searches to instead start at
 the bottom of the screen
 and backward searches to start at the top of the screen,
@@ -1131,6 +1132,9 @@ file name is typed in, and the same string is already in the history list,
 the existing copy is removed from the history list before the new one is added.
 Thus, a given string will appear only once in the history list.
 Normally, a string may appear multiple times.
+.IP "\-\-repeat-search-skip-screen"
+Causes repeated searches (the n and N commands) to ignore matches on the
+current screen.  This can be useful coupled with search highlighting.
 .IP "\-\-rscroll"
 This option changes the character used to mark truncated lines.
 It may begin with a two-character attribute indicator like LESSBINFMT does.

--- a/opttbl.c
+++ b/opttbl.c
@@ -64,6 +64,7 @@ public int status_col_width;    /* Width of status column */
 public int incr_search;         /* Incremental search */
 public int use_color;           /* Use UI color */
 public int want_filesize;       /* */
+public int repeat_skip_screen;  /* Repeated searches (n/N) start on next screen */
 #if HILITE_SEARCH
 public int hilite_search;       /* Highlight matched search patterns? */
 #endif
@@ -139,6 +140,7 @@ static struct optname status_col_width_optname = { "status-col-width", NULL };
 static struct optname incr_search_optname = { "incsearch",       NULL };
 static struct optname use_color_optname = { "use-color",         NULL };
 static struct optname want_filesize_optname = { "file-size",     NULL };
+static struct optname repeat_skip_optname = { "repeat-search-skip-screen", NULL };
 #if LESSTEST
 static struct optname ttyin_name_optname = { "tty",              NULL };
 static struct optname rstat_optname  = { "rstat",                NULL };
@@ -559,6 +561,14 @@ static struct loption option[] =
 		{
 			"Don't get size of each file",
 			"Get size of each file",
+			NULL
+		}
+	},
+	{ OLETTER_NONE, &repeat_skip_optname,
+		BOOL, OPT_OFF, &repeat_skip_screen, NULL,
+		{
+			"Repeated search (n/N) starts after target line",
+			"Repeated search (n/N) skips displayed screen",
 			NULL
 		}
 	},

--- a/search.c
+++ b/search.c
@@ -28,6 +28,7 @@ extern int jump_sline;
 extern int bs_mode;
 extern int ctldisp;
 extern int status_col;
+extern int repeat_skip_screen;
 extern void *ml_search;
 extern POSITION start_attnpos;
 extern POSITION end_attnpos;
@@ -1105,7 +1106,7 @@ search_pos(search_type)
 	{
 		int add_one = 0;
 
-		if (how_search == OPT_ON)
+		if (how_search == OPT_ON || (repeat_skip_screen && (search_type & SRCH_AFTER_TARGET)))
 		{
 			/*
 			 * Search does not include current screen.


### PR DESCRIPTION
The --repeat-search-skip-screen option causes repeated search (N/n) to start on
the next page.  I don't think that's possible with --search-skip-screen.

Normally I don't need to go through the matches one-by-one, I just want to see
where they are.  Because I've already seen all the matches on the screen I
don't need those pointed out again.  Skipping them saves a lot of time without
losing information.