### PR TITLE
Don't block on files that are not regular or block devices

### DIFF
--- a/edit.c
+++ b/edit.c
@@ -392,7 +392,11 @@ edit_ifile(ifile)
 			}
 			reedit_ifile(was_curr_ifile);
 			return (1);
+#ifdef OPEN_READ_NB
+		} else if ((f = open(open_filename, OPEN_READ_NB)) < 0)
+#else
 		} else if ((f = open(open_filename, OPEN_READ)) < 0)
+#endif
 		{
 			/*
 			 * Got an error trying to open it.

--- a/less.h
+++ b/less.h
@@ -245,6 +245,7 @@ typedef off_t           LINENUM;
 #else
 #ifdef O_RDONLY
 #define OPEN_READ       (O_RDONLY)
+#define OPEN_READ_NB    (O_RDONLY|O_NONBLOCK)
 #else
 #define OPEN_READ       (0)
 #endif


### PR DESCRIPTION
Less currently freezes if a named pipe on Linux does not have any input. 

`$ mkfifo /tmp/test`
`$ less -f /tmp/test`

This will make less nonblocking when reading from the named pipe.
Tested on OpenBSD and Gentoo Linux.