### PR TITLE
Don't add a new line filter if the pattern is invalid

### DIFF
--- a/search.c
+++ b/search.c
@@ -1908,7 +1908,12 @@ set_filter_pattern(pattern, search_type)
 		/* Create a new filter and add it to the filter_infos list. */
 		filter = ecalloc(1, sizeof(struct pattern_info));
 		init_pattern(filter);
-		set_pattern(filter, pattern, search_type, 1);
+		if (set_pattern(filter, pattern, search_type, 1) < 0)
+		{
+			clear_pattern(filter);
+			free(filter);
+			return;
+		}
 		filter->next = filter_infos;
 		filter_infos = filter;
 	}


### PR DESCRIPTION
less will crash if an invalid filter is added with & command.

To reproduce:
    - enter invalid pattern with &+
    - refresh screen (ctrl+L or similar)