### PR TITLE
Fixed buffer overflow by accessing metachars array

### DIFF
--- a/lessecho.c
+++ b/lessecho.c
@@ -205,10 +205,14 @@ main(argc, argv)
 				pr_error("Missing number after -p");
 			break;
 		case 'm':
+			if (num_metachars > 62)
+				pr_error("Too many metachars supplied");
 			metachars[num_metachars++] = *++arg;
 			metachars[num_metachars] = '\0';
 			break;
 		case 'n':
+			if (num_metachars > 62)
+				pr_error("Too many metachars supplied");
 			metachars[num_metachars++] = lstrtol(++arg, 0, &s);
 			if (s == arg)
 				pr_error("Missing number after -n");


### PR DESCRIPTION
Proof of concept:
Compiled with -fsanitize=address

lessecho $(perl -e 'print "-ma "x100')

Shoutout to [@c3h2_ctf](
https://twitter.com/c3h2_ctf
)