### PR TITLE
Fixed integer handling in lesskey files

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -784,7 +784,7 @@ new_lesskey(buf, len, sysvar)
 	int len;
 	int sysvar;
 {
-	char *p;
+	char *p, *end;
 	int c;
 	int n;
 
@@ -797,6 +797,7 @@ new_lesskey(buf, len, sysvar)
 	    buf[len-1] != C2_END_LESSKEY_MAGIC)
 		return (-1);
 	p = buf + 4;
+	end = buf + len - 3;
 	for (;;)
 	{
 		c = *p++;
@@ -804,16 +805,22 @@ new_lesskey(buf, len, sysvar)
 		{
 		case CMD_SECTION:
 			n = gint(&p);
+			if (n < 0 || p >= end)
+ 				return (-1);
 			add_fcmd_table(p, n);
 			p += n;
 			break;
 		case EDIT_SECTION:
 			n = gint(&p);
+			if (n < 0 || p >= end)
+ 				return (-1);
 			add_ecmd_table(p, n);
 			p += n;
 			break;
 		case VAR_SECTION:
 			n = gint(&p);
+			if (n < 0 || p >= end)
+ 				return (-1);
 			add_var_table((sysvar) ? 
 				&list_sysvar_tables : &list_var_tables, p, n);
 			p += n;


### PR DESCRIPTION
Proof of concept (endless loop):
echo "AE0rR2P9AEVuZA==" | base64 -d > lesskey.txt

Proof of concept (heap overflow):
Compiled with -fsanitize=address
echo "AE0rR2N/f0VuZA==" | base64 -d > lesskey.txt

Shoutout to [@c3h2_ctf](
https://twitter.com/c3h2_ctf
)