### PR TITLE
Ignore permanent marks in secure mode

### DIFF
--- a/mark.c
+++ b/mark.c
@@ -436,6 +436,8 @@ restore_mark(line)
 	POSITION pos;
 
 #define skip_whitespace while (*line == ' ') line++
+	if (secure)
+		return;
 	if (*line++ != 'm')
 		return;
 	skip_whitespace;


### PR DESCRIPTION
The secure mode restricts operations to only process files which have
been specified on command line.

If the previous less call has saved a mark in history file, then the
secure less could switch input files by accessing this mark.

Arguably the fact that the less history file can be accessed in this
way could be an information leak in itself since it reveals what a
previous user entered.

I do not consider this a security issue for three reasons:
- Someone would have to trick a user with extended permissions, i.e.
  someone who is not restricted to LESSSECURE, to set a mark.
- The access only works for the first less command which does not
  explicitly uses --save-marks since this less command would override
  the history file, removing all previously saved marks.
- The history feature can be removed during configuration. If less
  is supposed to be used in a critical environment, then it should be
  protected accordingly.

But this unexpected behavior should be fixed.

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)