### PR TITLE
Check malloc return value

### DIFF
--- a/lessecho.c
+++ b/lessecho.c
@@ -150,6 +150,9 @@ add_metachar(ch)
 		char *p;
 		size_metachars = (size_metachars > 0) ? size_metachars*2 : 16;
 		p = (char *) malloc(size_metachars);
+		if (p == NULL)
+			pr_error("Cannot allocate memory");
+
 		if (metachars != NULL)
 		{
 			strcpy(p, metachars);


### PR DESCRIPTION
If malloc return value is not checked then metachars can be NULL and
null pointer dereference is performed eventually

Shoutout to [@c3h2_ctf](
https://twitter.com/c3h2_ctf
)