### PR TITLE
Fix heap overflow with UTF-8 meta characters

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -760,7 +760,7 @@ lglob(filename)
 	SNPRINTF4(cmd, len, "%s -p0x%x -d0x%x -e%s ", lessecho, openquote, closequote, esc);
 	free(esc);
 	for (s = metachars();  *s != '\0';  s++)
-		sprintf(cmd + strlen(cmd), "-n0x%x ", *s);
+		sprintf(cmd + strlen(cmd), "-n0x%x ", (unsigned char) *s);
 	sprintf(cmd + strlen(cmd), "-- %s", filename);
 	fd = shellcmd(cmd);
 	free(cmd);


### PR DESCRIPTION
If a meta character has its high bit set, then the %x format would
interpret the character as a signed integer on most systems, i.e.
on systems which have signed chars instead of unsigned chars.

Cast *s to guarantee that only two hex digits are printed, otherwise
the allocated space would be not enough.

How to reproduce (-fsanitize=address, HAVE_POPEN setup, e.g. Linux):

LESSMETACHARS=$(echo -e '\xff') less -f /dev/null
(now type "-T x" and press enter to trigger lglob function call)

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)