### PR TITLE
Fix memory leaks

### DIFF
--- a/main.c
+++ b/main.c
@@ -140,7 +140,7 @@ main(argc, argv)
 
 	s = lgetenv(less_is_more ? "MORE" : "LESS");
 	if (s != NULL)
-		scan_option(save(s));
+		scan_option(s);
 
 #define isoptstring(s)  (((s)[0] == '-' || (s)[0] == '+') && (s)[1] != '\0')
 	while (argc > 0 && (isoptstring(*argv) || isoptpending()))

--- a/mark.c
+++ b/mark.c
@@ -59,6 +59,7 @@ cmark(m, ifile, pos, ln)
 	m->m_ifile = ifile;
 	m->m_scrpos.pos = pos;
 	m->m_scrpos.ln = ln;
+	free(m->m_filename);
 	m->m_filename = NULL;
 }
 


### PR DESCRIPTION
If LESS or MORE environment variable is set, then a copy of the value
is created for scan_option call. Release memory after scan_option has
been performed.

Also handle rare cases in which a history file has duplicated mark
entries.

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)