### PR TITLE
Increase buffer size for header query output

### DIFF
--- a/optfunc.c
+++ b/optfunc.c
@@ -1021,7 +1021,7 @@ opt_header(type, s)
 		break;
 	case QUERY:
 		{
-			char buf[16];
+			char buf[INT_STRLEN_BOUND(int)+4];
 			PARG parg;
 			SNPRINTF2(buf, sizeof(buf), "%d,%d", header_lines, header_cols);
 			parg.p_string = buf;


### PR DESCRIPTION
Very large header values cannot be represented with current buf array.
Since snprintf is used no buffer overflow occurs, therefore this is a
simple cleanup commit.

How to reproduce:

Type "--header 12345,123456789" in less, then type "--header" and
press enter. The column output is truncated (digit 9 is missing).

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)