### PR TITLE
Fix buffer overflow with invalid quotes

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -757,7 +757,8 @@ lglob(filename)
 	 */
 	len = (int) (strlen(lessecho) + strlen(filename) + (7*strlen(metachars())) + 24);
 	cmd = (char *) ecalloc(len, sizeof(char));
-	SNPRINTF4(cmd, len, "%s -p0x%x -d0x%x -e%s ", lessecho, openquote, closequote, esc);
+	SNPRINTF4(cmd, len, "%s -p0x%x -d0x%x -e%s ", lessecho,
+		(unsigned char) openquote, (unsigned char) closequote, esc);
 	free(esc);
 	for (s = metachars();  *s != '\0';  s++)
 		sprintf(cmd + strlen(cmd), "-n0x%x ", (unsigned char) *s);


### PR DESCRIPTION
A follow-up commit to 6f49ad006b09ecbe535de6f62fde867d4197c551.
The quotes can have their upper bits set in which case more than just
two digits are printed, eventually overflowing the allocated memory.

How to reproduce:

less --quotes=$(echo -e '\xff\xff') -f /dev/null
Then enter "-T x" to trigger lglob function

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)