### PR TITLE
Fix integer overflow in match_brac()

### DIFF
--- a/brac.c
+++ b/brac.c
@@ -84,7 +84,11 @@ match_brac(obrac, cbrac, forwdir, n)
 	while ((c = (*chget)()) != EOI)
 	{
 		if (c == obrac)
+		{
+			if (nest == INT_MAX)
+				break;
 			nest++;
+		}
 		else if (c == cbrac && --nest < 0)
 		{
 			/*


### PR DESCRIPTION
PoC:
compile with fsanitize=undefined
Created file with 2^31 opening brackets
python -c 'for i in range(8388609): print("{"*256)' > poc.txt
less poc.txt
enter: {

Shoutout to [@c3h2_ctf](
https://twitter.com/c3h2_ctf
)