### PR TITLE
Fix floating point exception in protochar

### DIFF
--- a/prompt.c
+++ b/prompt.c
@@ -277,7 +277,7 @@ protochar(c, where, iseditproto)
 		break;
 	case 'd': /* Current page number */
 		linenum = currline(where);
-		if (linenum > 0 && sc_height > 1)
+		if (linenum > 0 && (sc_height - header_lines) > 1)
 			ap_linenum(PAGE_NUM(linenum));
 		else
 			ap_quest();


### PR DESCRIPTION
If --header is set to "LINES - 1", i.e. one line less than
the screen height, then a "%d" in a prompt is not resolved
properly but crashes less instead.

How to reproduce (assuming your screen height is 25):
yes y | less --header 24 -P '%d'

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)