### PR TITLE
Increment parg for characters in less_printf

### DIFF
--- a/output.c
+++ b/output.c
@@ -596,6 +596,7 @@ less_printf(fmt, parg)
 			case 'c':
 				putchr(parg->p_char);
 				col++;
+				parg++;
 				break;
 			case '%':
 				putchr('%');


### PR DESCRIPTION
The parg pointer is not incremented for %c formatted arguments. This
has no negative impact on less because no less_printf formatter uses
another argument after %c.

This is a purely defensive commit.

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)