### PR TITLE
Update README INSTALLATION section

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,7 @@ INSTALLATION (Unix & Linux systems only):
    if you have not already done so.  
 
 2. If you are building from a clone of a git repository,
-   type "make -f Makefile.aut".
+   type "make -f Makefile.aut distfiles".
    If you are building from a numbered release package (a tar or 
    zip file with a name like less-999.tar.gz or less-999.zip downloaded 
    from greenwoodsoftware.com, not from github), you should skip this step. 


### PR DESCRIPTION
As per [#139](https://github.com/gwsw/less/issues/139#issuecomment-832064664), there was a missing target for the installation steps, which made it fail to install. This commit fixes that.

Signed-off-by: Isabella Basso <isabbasso@riseup.net>