### PR TITLE
Support XDG_STATE_HOME for lesshst

### DIFF
--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -78,16 +78,16 @@ struct mlist
 /*
  * These are the various command histories that exist.
  */
-struct mlist mlist_search =  
+struct mlist mlist_search =
 	{ &mlist_search,  &mlist_search,  &mlist_search,  NULL, 0 };
 public void *ml_search = (void *) &mlist_search;
 
-struct mlist mlist_examine = 
+struct mlist mlist_examine =
 	{ &mlist_examine, &mlist_examine, &mlist_examine, NULL, 0 };
 public void *ml_examine = (void *) &mlist_examine;
 
 #if SHELL_ESCAPE || PIPEC
-struct mlist mlist_shell =   
+struct mlist mlist_shell =
 	{ &mlist_shell,   &mlist_shell,   &mlist_shell,   NULL, 0 };
 public void *ml_shell = (void *) &mlist_shell;
 #endif
@@ -403,7 +403,7 @@ cmd_right(VOID_PARAM)
 	char *pr;
 	char *ncp;
 	int width;
-	
+
 	if (*cp == '\0')
 	{
 		/* Already at the end of the line. */
@@ -469,14 +469,14 @@ cmd_ichar(cs, clen)
 	int clen;
 {
 	char *s;
-	
+
 	if (strlen(cmdbuf) + clen >= sizeof(cmdbuf)-1)
 	{
 		/* No room in the command buffer for another char. */
 		bell();
 		return (CC_ERROR);
 	}
-		
+
 	/*
 	 * Make room for the new character (shift the tail of the buffer right).
 	 */
@@ -536,7 +536,7 @@ cmd_erase(VOID_PARAM)
 	 */
 	updown_match = -1;
 	cmd_repaint(cp);
-	
+
 	/*
 	 * We say that erasing the entire command string causes us
 	 * to abort the current command, if CF_QUIT_ON_ERASE is set.
@@ -673,7 +673,7 @@ cmd_updown(action)
 {
 	constant char *s;
 	struct mlist *ml;
-	
+
 	if (curr_mlist == NULL)
 	{
 		/*
@@ -764,7 +764,7 @@ cmd_addhist(mlist, cmd, modified)
 {
 #if CMD_HISTORY
 	struct mlist *ml;
-	
+
 	/*
 	 * Don't save a trivial command.
 	 */
@@ -848,7 +848,7 @@ cmd_edit(c)
 #else
 #define not_in_completion(VOID_PARAM)
 #endif
-	
+
 	/*
 	 * See if the char is indeed a line-editing command.
 	 */
@@ -959,7 +959,7 @@ cmd_istr(str)
 	char *s;
 	int action;
 	char *endline = str + strlen(str);
-	
+
 	for (s = str;  *s != '\0';  )
 	{
 		char *os = s;
@@ -988,7 +988,7 @@ delimit_word(VOID_PARAM)
 	constant char *esc = get_meta_escape();
 	int esclen = (int) strlen(esc);
 #endif
-	
+
 	/*
 	 * Move cursor to end of word.
 	 */
@@ -1061,7 +1061,7 @@ delimit_word(VOID_PARAM)
 
 /*
  * Set things up to enter completion mode.
- * Expand the word under the cursor into a list of filenames 
+ * Expand the word under the cursor into a list of filenames
  * which start with that word, and set tk_text to that list.
  */
 	static void
@@ -1069,7 +1069,7 @@ init_compl(VOID_PARAM)
 {
 	char *word;
 	char c;
-	
+
 	/*
 	 * Get rid of any previous tk_text.
 	 */
@@ -1158,8 +1158,8 @@ cmd_complete(action)
 	if (!in_completion || action == EC_EXPAND)
 	{
 		/*
-		 * Expand the word under the cursor and 
-		 * use the first word in the expansion 
+		 * Expand the word under the cursor and
+		 * use the first word in the expansion
 		 * (or the entire expansion if we're doing EC_EXPAND).
 		 */
 		init_compl();
@@ -1191,13 +1191,13 @@ cmd_complete(action)
 		 */
 		tk_trial = next_compl(action, tk_trial);
 	}
-	
+
 	/*
 	 * Remove the original word, or the previous trial completion.
 	 */
 	while (cp > tk_ipoint)
 		(void) cmd_erase();
-	
+
 	if (tk_trial == NULL)
 	{
 		/*
@@ -1228,9 +1228,9 @@ cmd_complete(action)
 				goto fail;
 		}
 	}
-	
+
 	return (CC_OK);
-	
+
 fail:
 	in_completion = 0;
 	bell();
@@ -1318,7 +1318,7 @@ cmd_char(c)
 		literal = 0;
 		return (cmd_ichar(cmd_mbc_buf, len));
 	}
-		
+
 	/*
 	 * See if it is a line-editing character.
 	 */
@@ -1334,7 +1334,7 @@ cmd_char(c)
 			break;
 		}
 	}
-	
+
 	/*
 	 * Insert the char into the command buffer.
 	 */
@@ -1408,7 +1408,7 @@ histfile_name(must_exist)
 	char *home;
 	char *xdg;
 	char *name;
-	
+
 	/* See if filename is explicitly specified by $LESSHISTFILE. */
 	name = lgetenv("LESSHISTFILE");
 	if (!isnullenv(name))
@@ -1433,7 +1433,7 @@ histfile_name(must_exist)
 	name = NULL;
 	if (!must_exist)
 	{
-	 	/* If we're writing the file and the file already exists, use it. */
+		/* If we're writing the file and the file already exists, use it. */
 		name = dirfile(xdg, &LESSHISTFILE[1], 1);
 		if (name == NULL)
 			name = dirfile(home, LESSHISTFILE, 1);

--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -1406,7 +1406,8 @@ histfile_name(must_exist)
 	int must_exist;
 {
 	char *home;
-	char *xdg;
+	char *xdg_data;
+	char *xdg_state;
 	char *name;
 
 	/* See if filename is explicitly specified by $LESSHISTFILE. */
@@ -1423,8 +1424,9 @@ histfile_name(must_exist)
 	if (strcmp(LESSHISTFILE, "") == 0 || strcmp(LESSHISTFILE, "-") == 0)
 		return (NULL);
 
-	/* Try in $XDG_DATA_HOME first, then in $HOME. */
-	xdg = lgetenv("XDG_DATA_HOME");
+	/* Try in $XDG_STATE_HOME first, then $XDG_DATA_HOME and $HOME. */
+	xdg_data = lgetenv("XDG_DATA_HOME");
+	xdg_state = lgetenv("XDG_STATE_HOME");
 	home = lgetenv("HOME");
 #if OS2
 	if (isnullenv(home))
@@ -1434,12 +1436,16 @@ histfile_name(must_exist)
 	if (!must_exist)
 	{
 		/* If we're writing the file and the file already exists, use it. */
-		name = dirfile(xdg, &LESSHISTFILE[1], 1);
+		name = dirfile(xdg_state, &LESSHISTFILE[1], 1);
+		if (name == NULL)
+			name = dirfile(xdg_data, &LESSHISTFILE[1], 1);
 		if (name == NULL)
 			name = dirfile(home, LESSHISTFILE, 1);
 	}
 	if (name == NULL)
-		name = dirfile(xdg, &LESSHISTFILE[1], must_exist);
+		name = dirfile(xdg_state, &LESSHISTFILE[1], must_exist);
+	if (name == NULL)
+		name = dirfile(xdg_data, &LESSHISTFILE[1], must_exist);
 	if (name == NULL)
 		name = dirfile(home, LESSHISTFILE, must_exist);
 	return (name);

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -1976,7 +1976,7 @@ Name of the history file used to remember search commands and
 shell commands between invocations of
 .IR less .
 If set to "\-" or "/dev/null", a history file is not used.
-The default is "$XDG_DATA_HOME/lesshst" or "$HOME/.lesshst" on Unix systems,
+The default is "$XDG_STATE_HOME/lesshst", "$XDG_DATA_HOME" or "$HOME/.lesshst" on Unix systems,
 "$HOME/_lesshst" on DOS and Windows systems,
 or "$HOME/lesshst.ini" or "$INIT/lesshst.ini"
 on OS/2 systems.

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -573,7 +573,7 @@ The \-d option does not otherwise change the behavior of
 on a dumb terminal.
 .IP "\-D\fBx\fP\fIcolor\fP or \-\-color=\fBx\fP\fIcolor\fP"
 Changes the color of different parts of the displayed text.
-\fBx\fP is a single character which selects the type of text 
+\fBx\fP is a single character which selects the type of text
 whose color is being set:
 .RS
 .IP "B"
@@ -605,16 +605,16 @@ Standout text.
 .IP "u"
 Underlined text.
 .RE
- 
+
 .RS
 The uppercase letters can be used only when the \-\-use-color option is enabled.
 When text color is specified by both an uppercase letter and a lowercase letter,
-the uppercase letter takes precedence. 
+the uppercase letter takes precedence.
 For example, error messages are normally displayed as standout text.
 So if both "s" and "E" are given a color, the "E" color applies
 to error messages, and the "s" color applies to other standout text.
-The "d" and "u" letters refer to bold and underline text formed by 
-overstriking with backspaces (see the \-u option), 
+The "d" and "u" letters refer to bold and underline text formed by
+overstriking with backspaces (see the \-u option),
 not to text using ANSI escape sequences with the \-R option.
 .PP
 A lowercase letter may be followed by a + to indicate that
@@ -625,8 +625,8 @@ But \-Du+g displays underlined text as both green and in underlined format.
 .PP
 \fIcolor\fP is either a 4-bit color string or an 8-bit color string:
 .PP
-A 4-bit color string is zero, one or two characters, where 
-the first character specifies the foreground color and 
+A 4-bit color string is zero, one or two characters, where
+the first character specifies the foreground color and
 the second specifies the background color as follows:
 .IP "b"
 Blue
@@ -646,14 +646,14 @@ White
 Yellow
 .PP
 The corresponding upper-case letter denotes a brighter shade of the color.
-For example, \-DNGk displays line numbers as bright green text on a black 
-background, and \-DEbR displays error messages as blue text on a 
+For example, \-DNGk displays line numbers as bright green text on a black
+background, and \-DEbR displays error messages as blue text on a
 bright red background.
-If either character is a "-" or is omitted, the corresponding color 
+If either character is a "-" or is omitted, the corresponding color
 is set to that of normal text.
 .PP
 An 8-bit color string is one or two decimal integers separated by a dot,
-where the first integer specifies the foreground color and 
+where the first integer specifies the foreground color and
 the second specifies the background color.
 Each integer is a value between 0 and 255 inclusive which selects
 a "CSI 38;5" color value (see
@@ -663,11 +663,11 @@ https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters)
 .hy
 If either integer is a "-" or is omitted,
 the corresponding color is set to that of normal text.
-On MS-DOS versions of 
+On MS-DOS versions of
 .IR less ,
 8-bit color is not supported; instead, decimal values are interpreted as 4-bit
 CHAR_INFO.Attributes values
-(see 
+(see
 .br
 .nh
 https://docs.microsoft.com/en-us/windows/console/char-info-str).
@@ -772,9 +772,9 @@ file.
 .IP "\-\-lesskey-src=\fIfilename\fP"
 Causes
 .I less
-to open and interpret the named file as a 
+to open and interpret the named file as a
 .IR lesskey (1)
-source file. 
+source file.
 If the LESSKEYIN or LESSKEYIN_SYSTEM environment variable is set, or
 if a lesskey source file is found in a standard place (see KEY BINDINGS),
 it is also used as a
@@ -782,9 +782,9 @@ it is also used as a
 file.
 Prior to version 582, the
 .I lesskey
-program needed to be run to convert a 
+program needed to be run to convert a
 .I "lesskey source"
-file to a 
+file to a
 .I "lesskey binary"
 file for
 .I less
@@ -914,10 +914,10 @@ USE OF THE \-r OPTION IS NOT RECOMMENDED.
 Like \-r, but only ANSI "color" escape sequences and OSC 8 hyperlink
 sequences are output in "raw" form.
 Unlike \-r, the screen appearance is maintained correctly,
-provided that there are no escape sequences in the file 
+provided that there are no escape sequences in the file
 other than these types of escape sequences.
 Color escape sequences are only supported when the color
-is changed within one line, not across lines. 
+is changed within one line, not across lines.
 In other words, the beginning of each line is assumed to be
 normal (non-colored), regardless of any escape sequences in previous lines.
 For the purpose of keeping track of screen appearance,
@@ -927,7 +927,7 @@ OSC 8 hyperlinks are sequences of the form:
 .sp
 	ESC ] 8 ; \&...\& \\7
 .sp
-The terminating sequence may be either a BEL character (\\7) 
+The terminating sequence may be either a BEL character (\\7)
 or the two-character sequence "ESC \\".
 .sp
 ANSI color escape sequences are sequences of the form:
@@ -969,7 +969,7 @@ If the environment variable LESSGLOBALTAGS is set, it is taken to be
 the name of a command compatible with
 .IR global (1),
 and that command is executed to find the tag.
-(See 
+(See
 .nh
 http://www.gnu.org/software/global/global.html).
 .hy
@@ -1088,7 +1088,7 @@ of the screen width.
 .IP "\-\-file-size"
 If \-\-file-size is specified,
 .I less
-will determine the size of the file 
+will determine the size of the file
 immediately after opening the file.
 Normally this is not done, because it can be slow if the input file is large.
 .IP "\-\-follow-name"
@@ -1108,15 +1108,15 @@ will display the contents of that new file.
 Sets the number of header lines and columns displayed on the screen.
 The value may be of the form "N,M" where N and M are integers,
 to set the header lines to N and the header columns to M,
-or it may be a single integer "N" which sets the header lines to N 
+or it may be a single integer "N" which sets the header lines to N
 and the header columns to zero.
 When N is nonzero, the first N lines at the top
 of the screen are replaced with the first N lines of the file,
 regardless of what part of the file are being viewed.
-When M is nonzero, the characters displayed at the 
+When M is nonzero, the characters displayed at the
 beginning of each line are replaced with the first M characters of the line,
 even if the rest of the line is scrolled horizontally.
-If either N or M is zero, 
+If either N or M is zero,
 .I less
 stops displaying header lines or columns, respectively.
 (Note that it may be neccessary to change the setting of the \-j option
@@ -1124,7 +1124,7 @@ to ensure that the target line is not obscured by the header line(s).)
 .IP "\-\-incsearch"
 Subsequent search commands will be "incremental"; that is,
 .I less
-will advance to the next line containing the search pattern 
+will advance to the next line containing the search pattern
 as each character of the pattern is typed in.
 .IP "\-\-line-num-width"
 Sets the minimum width of the line number field when the \-N option is in effect.
@@ -1166,7 +1166,7 @@ If set to "\-", truncated lines are not marked.
 When quitting, after sending the terminal deinitialization string,
 redraws the entire last screen.
 On terminals whose terminal deinitialization string causes the
-terminal to switch from an alternate screen, 
+terminal to switch from an alternate screen,
 this makes the last screenful of the current file remain visible after
 .I less
 has quit.
@@ -1175,7 +1175,7 @@ Save marks in the history file, so marks are retained
 across different invocations of
 .IR less .
 .IP "\-\-search-options"
-Sets default search modifiers. 
+Sets default search modifiers.
 The value is a string of one or more of the characters
 E, F, K, N, R or W.
 Setting any of these has the same effect as typing that
@@ -1200,9 +1200,9 @@ This allows a dollar sign to be included in option strings.
 .IP "\-\-use-color"
 Enables the colored text in various places.
 The -D option can be used to change the colors.
-Colored text works only if the terminal supports 
+Colored text works only if the terminal supports
 ANSI color escape sequences (as defined in ECMA-48 SGR;
-see 
+see
 .br
 .nh
 https://www.ecma-international.org/publications-and-standards/standards/ecma-48).
@@ -1495,9 +1495,9 @@ is interpreted as meaning there is no replacement, and
 the original file is used.
 To avoid this, if LESSOPEN starts with two vertical bars,
 the exit status of the script determines the behavior when the output is empty.
-If the output is empty and the exit status is zero, 
+If the output is empty and the exit status is zero,
 the empty output is considered to be replacement text.
-If the output is empty and the exit status is nonzero, 
+If the output is empty and the exit status is nonzero,
 the original file is used.
 For compatibility with previous versions of
 .IR less ,


### PR DESCRIPTION
The XDG added in v0.8 the $XDG_STATE_HOME directory to store state files, such as history files.

This merge-request migrates to prefer $XDG_STATE_HOME, but keeps $XDG_DATA_HOME for backwards compatibility, as that was already released into the wild.

While here, a boyscout commit fixes some line-ending bugs.