### PR TITLE
--help's -n -N wrong

### DIFF
--- a/less.hlp
+++ b/less.hlp
@@ -161,8 +161,10 @@
                   Ignore the LESSOPEN environment variable.
   -m  -M  ....  --long-prompt  --LONG-PROMPT
                   Set prompt style.
-  -n  -N  ....  --line-numbers  --LINE-NUMBERS
-                  Don't use line numbers.
+  -n --line-numbers
+                  Suppress line number in prompt.
+  -N --LINE-NUMBERS
+                  Line number each line.
   -o [_f_i_l_e]  .  --log-file=[_f_i_l_e]
                   Copy to log file (standard input only).
   -O [_f_i_l_e]  .  --LOG-FILE=[_f_i_l_e]


### PR DESCRIPTION
$ less --help
```
  -n  -N  ....  --line-numbers  --LINE-NUMBERS
                  Don't use line numbers.
```
Utterly wrong. Say instead:
```
  -n --line-numbers
                  Suppress line number in prompt.
  -N --LINE-NUMBERS
                  Line number each line.
```