### PR TITLE
Fix signal race in iread.

### DIFF
--- a/os.c
+++ b/os.c
@@ -158,7 +158,10 @@ start:
 		FD_ZERO(&readfds);
 		FD_SET(fd, &readfds);
 		if (select(fd+1, &readfds, 0, 0, 0) == -1)
+		{
+			reading = 0;
 			return (-1);
+		}
 	}
 #endif
 #if USE_POLL
@@ -167,11 +170,13 @@ start:
 		if (poll_events(tty, POLLIN) && getchr() == CONTROL('X'))
 		{
 			sigs |= S_INTERRUPT;
+			reading = 0;
 			return (READ_INTR);
 		}
 		if (poll_events(fd, POLLERR|POLLHUP))
 		{
 			sigs |= S_INTERRUPT;
+			reading = 0;
 			return (READ_INTR);
 		}
 	}
@@ -180,6 +185,7 @@ start:
 	if (win32_kbhit() && WIN32getch() == CONTROL('X'))
 	{
 		sigs |= S_INTERRUPT;
+		reading = 0;
 		return (READ_INTR);
 	}
 #endif
@@ -199,7 +205,10 @@ start:
 			else
 				consecutive_nulls = 0;
 			if (consecutive_nulls > 20)
+			{
+				reading = 0;
 				quit(QUIT_ERROR);
+			}
 		}
 	}
 #endif


### PR DESCRIPTION
The variable reading is used to indicate that ^C and other signals shall
"interrupt" a read call by performing a long jump. The jump target is
set within iread function.

Make sure that reading is always set back to 0 when iread is left, since
jumping to the target after leaving the target function is undefined
behavior.

This can be triggered on Linux systems (very hard to reach without
a debugger or another way to have enough time at the right spot):

term1$ mkfifo fifo
term2$ (yes y | head -n 50; read) > fifo
term1$ gdb less
\> break null_line
\> run -f fifo
[press F in less to set ignore_eoi to 1]
[kill fifo feeding process in term2, e.g. CTRL+C]
\> signal SIGINT

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)