### PR TITLE
Document lesskey command actions

### DIFF
--- a/lesskey.nro.VER
+++ b/lesskey.nro.VER
@@ -1,7 +1,7 @@
 '\" t
 .TH LESSKEY 1 "Version @@VERSION@@: @@DATE@@"
 .SH NAME
-lesskey \- specify key bindings for less
+lesskey \- customize key bindings for less
 .SH "SYNOPSIS (deprecated)"
 .B "lesskey [\-o output] [\-\-] [input]"
 .br
@@ -42,9 +42,9 @@ The input file consists of one or more
 Each section starts with a line that identifies the type of section.
 Possible sections are:
 .IP #command
-Defines new command keys.
+Customizes command key bindings.
 .IP #line-edit
-Defines new line-editing keys.
+Customizes line-editing key bindings.
 .IP #env
 Defines environment variables.
 .PP


### PR DESCRIPTION
I don't consider this pull request mature, but I thought it would be best to show you what I'm talking about, rather than trying to describe it.

When reading the lesskey man page, I felt like there was a missing section. This was written in it:

> The action is the name of the less action, from the list below.

But there is no such list in the man page. There is only an example, but no explanation of what each action does. Of course, one could try to open the less and lesskey man pages side-by-side and figure out like that, what each action does, but I feel like this is quite tedious. I would prefer there to be a list of all actions, with a description of what they do.

The `debug` action is undocumented right now and could also be documented in the lesskey man page (I have just added the placeholder "TODO" in this pull request).

There are also aliases for some actions, that are undocumented right now, e.g. `flush-repaint`, `end`, `toggle-flag`, ...

----

For this pull request I have simply copied the documentation from the less man page to the lesskey man page and adapted it a little bit to reference other actions rather than less commands. Maybe, however, something else would be better. Maybe a more brief description and a hint to look at the less man page for more info would be better.