### PR TITLE
Fix typos

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -268,7 +268,7 @@ expand_special_keys(table, len)
 			}
 			/*
 			 * After SK_SPECIAL_KEY, next byte is the type
-			 * of special key (one of the SK_* contants),
+			 * of special key (one of the SK_* constants),
 			 * and the byte after that is the number of bytes,
 			 * N, reserved by the abbreviation (including the
 			 * SK_SPECIAL_KEY and key type bytes).

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -1119,7 +1119,7 @@ even if the rest of the line is scrolled horizontally.
 If either N or M is zero, 
 .I less
 stops displaying header lines or columns, respectively.
-(Note that it may be neccessary to change the setting of the \-j option
+(Note that it may be necessary to change the setting of the \-j option
 to ensure that the target line is not obscured by the header line(s).)
 .IP "\-\-incsearch"
 Subsequent search commands will be "incremental"; that is,

--- a/line.c
+++ b/line.c
@@ -42,7 +42,7 @@ struct xbuffer shifted_ansi;
 /*
  * Ring buffer of last ansi sequences sent.
  * While sending a line, these will be resent at the end
- * of any hilighted string, to restore text modes.
+ * of any highlighted string, to restore text modes.
  * {{ Not ideal, since we don't really know how many to resend. }}
  */
 #define NUM_LAST_ANSIS 3

--- a/search.c
+++ b/search.c
@@ -944,7 +944,7 @@ add_hilite(anchor, hl)
 }
 
 /*
- * Hilight every character in a range of displayed characters.
+ * Highlight every character in a range of displayed characters.
  */
 	static void
 create_hilites(linepos, start_index, end_index, chpos)


### PR DESCRIPTION
Based on "neccessary" typo correction found by a1346054 in
https://github.com/gwsw/less/pull/193/commits/8d7314d4d18574106580a12b1c9ba5e77529bc22
and extended with findings by codespell.

I did not adjust NEWS and version.c since the typos in there are
more of "historical data."