### PR TITLE
Fix stack buffer overflow

### DIFF
--- a/lesskey_parse.c
+++ b/lesskey_parse.c
@@ -133,7 +133,8 @@ parse_error(fmt, arg1)
 {
 	char buf[1024];
 	int n = snprintf(buf, sizeof(buf), "%s: line %d: ", lesskey_file, linenum);
-	snprintf(buf+n, sizeof(buf)-n, fmt, arg1);
+	if (n >= 0 && n < sizeof(buf))
+		snprintf(buf+n, sizeof(buf)-n, fmt, arg1);
 	++errors;
 	lesskey_parse_error(buf);
 }


### PR DESCRIPTION
The adjustment of parse_error introduced a possible stack buffer
overflow if lesskey filename is long enough.

How to reproduce:

KEYFILE=$(python -c 'print("/tmp/"+4*(255*"a"+"/")+"lesskey.txt")')
install -d $(dirname KEYFILE)
echo "#version a" > $KEYFILE
less --lesskey-src=$KEYFILE -f /dev/null