### PR TITLE
Fix int overflow in cmdbuf number parser

### DIFF
--- a/charset.c
+++ b/charset.c
@@ -143,6 +143,7 @@ ichardef(s)
 	char *s;
 {
 	char *cp;
+	int digit;
 	int n;
 	char v;
 
@@ -165,7 +166,15 @@ ichardef(s)
 
 		case '0': case '1': case '2': case '3': case '4':
 		case '5': case '6': case '7': case '8': case '9':
-			n = (10 * n) + (s[-1] - '0');
+			digit = s[-1] - '0';
+			if (n < INT_MAX / 10 ||
+			    (n == INT_MAX / 10 && digit <= INT_MAX % 10))
+				n = 10 * n + digit;
+			else
+			{
+				error("invalid chardef", NULL_PARG);
+				quit(QUIT_ERROR);
+			}
 			continue;
 
 		default:

--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -1355,13 +1355,13 @@ cmd_int(frac)
 
 	for (p = cmdbuf;  *p >= '0' && *p <= '9';  p++)
 	{
-		LINENUM nn = (n * 10) + (*p - '0');
-		if (nn < n)
+		int digit = *p - '0';
+		if (n > INT_MAX / 10 || (n == INT_MAX / 10 && digit > INT_MAX % 10))
 		{
 			error("Integer is too big", NULL_PARG);
 			return (0);
 		}
-		n = nn;
+		n = (n * 10) + digit;
 	}
 	*frac = 0;
 	if (*p++ == '.')

--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -1350,18 +1350,13 @@ cmd_int(frac)
 	long *frac;
 {
 	char *p;
-	LINENUM n = 0;
 	int err;
+	LINENUM n = lstrtopos(cmdbuf, &p);
 
-	for (p = cmdbuf;  *p >= '0' && *p <= '9';  p++)
+	if (n == -1)
 	{
-		int digit = *p - '0';
-		if (n > INT_MAX / 10 || (n == INT_MAX / 10 && digit > INT_MAX % 10))
-		{
-			error("Integer is too big", NULL_PARG);
-			return (0);
-		}
-		n = (n * 10) + digit;
+		error("Integer is too big", NULL_PARG);
+		return (0);
 	}
 	*frac = 0;
 	if (*p++ == '.')

--- a/configure.ac
+++ b/configure.ac
@@ -186,6 +186,7 @@ AC_CHECK_HEADERS([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h ter
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STAT
 AC_C_CONST
+AC_TYPE_LONG_LONG_INT
 AC_TYPE_OFF_T
 AC_TYPE_SIZE_T
 AC_HEADER_TIME

--- a/decode.c
+++ b/decode.c
@@ -490,6 +490,7 @@ getcc_int(pterm)
 {
 	int num = 0;
 	int digits = 0;
+	int digit;
 	for (;;)
 	{
 		char ch = getcc();
@@ -500,8 +501,13 @@ getcc_int(pterm)
 				return (-1);
 			return (num);
 		}
-		num = (10 * num) + (ch - '0');
-		++digits;
+		digit = ch - '0';
+		if (num < INT_MAX / 10 ||
+		    (num == INT_MAX / 10 && digit <= INT_MAX % 10))
+			num = 10 * num + digit;
+		else
+			num = INT_MAX;
+		digits = 1;
 	}
 }
 

--- a/mark.c
+++ b/mark.c
@@ -447,12 +447,16 @@ restore_mark(line)
 		return;
 	skip_whitespace;
 	ln = lstrtoi(line, &line);
+	if (ln == -1)
+		return;
 	if (ln < 1)
 		ln = 1;
 	if (ln > sc_height)
 		ln = sc_height;
 	skip_whitespace;
 	pos = lstrtopos(line, &line);
+	if (pos == -1)
+		return;
 	skip_whitespace;
 	cmark(m, NULL_IFILE, pos, ln);
 	m->m_filename = save(line);

--- a/optfunc.c
+++ b/optfunc.c
@@ -735,10 +735,9 @@ opt_x(type, s)
 		/* Start at 1 because tabstops[0] is always zero. */
 		for (i = 1;  i < TABSTOP_MAX;  )
 		{
-			int n = 0;
+			int n;
 			s = skipsp(s);
-			while (*s >= '0' && *s <= '9')
-				n = (10 * n) + (*s++ - '0');
+			n = lstrtoi(s, &s);
 			if (n > tabstops[i-1])
 				tabstops[i++] = n;
 			s = skipsp(s);

--- a/option.c
+++ b/option.c
@@ -654,6 +654,7 @@ getnum(sp, printopt, errp)
 	int *errp;
 {
 	char *s;
+	int digit;
 	int n;
 	int neg;
 
@@ -667,9 +668,9 @@ getnum(sp, printopt, errp)
 	if (*s < '0' || *s > '9')
 		return (num_error(printopt, errp));
 
-	n = 0;
-	while (*s >= '0' && *s <= '9')
-		n = 10 * n + *s++ - '0';
+	n = lstrtoi(s, &s);
+	if (n == -1)
+		n = INT_MAX;
 	*sp = s;
 	if (errp != NULL)
 		*errp = FALSE;
@@ -699,16 +700,13 @@ getfraction(sp, printopt, errp)
 		return (num_error(printopt, errp));
 
 	for ( ;  *s >= '0' && *s <= '9';  s++)
-	{
-		frac = (frac * 10) + (*s - '0');
-		fraclen++;
-	}
-	if (fraclen > NUM_LOG_FRAC_DENOM)
-		while (fraclen-- > NUM_LOG_FRAC_DENOM)
-			frac /= 10;
-	else
-		while (fraclen++ < NUM_LOG_FRAC_DENOM)
-			frac *= 10;
+		if (fraclen < NUM_LOG_FRAC_DENOM)
+		{
+			frac = (frac * 10) + (*s - '0');
+			fraclen++;
+		}
+	while (fraclen++ < NUM_LOG_FRAC_DENOM)
+		frac *= 10;
 	*sp = s;
 	if (errp != NULL)
 		*errp = FALSE;

--- a/output.c
+++ b/output.c
@@ -502,19 +502,29 @@ TYPE_TO_A_FUNC(inttoa, int)
 
 /*
  * Convert an string to an integral type.
+ * Return -1 if number does not fit into integral type.
  */
 #define STR_TO_TYPE_FUNC(funcname, type) \
 type funcname(buf, ebuf) \
 	char *buf; \
 	char **ebuf; \
 { \
-	type val = 0; \
+	unsigned long long val = 0; \
+	type res = 0; \
 	for (;; buf++) { \
 		char c = *buf; \
+		int digit; \
 		if (c < '0' || c > '9') break; \
-		val = 10 * val + c - '0'; \
+		digit = c - '0'; \
+		if (val < LLONG_MAX / 10 || \
+		    (val == LLONG_MAX / 10 && digit <= LLONG_MAX % 10)) \
+			val = 10 * val + digit; \
+		else \
+			val = ULONG_MAX; \
 	} \
 	if (ebuf != NULL) *ebuf = buf; \
+	if ((type) val < 0 || (type) val != (long long) val || val > LLONG_MAX) \
+		return -1; \
 	return val; \
 }
 

--- a/screen.c
+++ b/screen.c
@@ -1664,7 +1664,8 @@ ltputs(str, affcnt, f_putc)
 				if (*str == '*')
 					delay *= affcnt;
 				flush();
-				sleep_ms(delay);
+				if (delay >= 0)
+					sleep_ms(delay);
 				/* Skip past closing ">" at end of delay string. */
 				str = strstr(str, ">");
 				if (str != NULL)
@@ -2468,7 +2469,7 @@ parse_color6(ps)
 	{
 		char *ops = *ps;
 		int color = lstrtoi(ops, ps);
-		if (*ps == ops)
+		if (*ps == ops || color == -1)
 			return CV_ERROR;
 		return color;
 	}


### PR DESCRIPTION
Checking for an overflow after it has occurred is too late, so the overflow check needs to happen before the calculation.

### Reproduce

Compile with `-fsanitize=undefined`

```
CFLAGS='-fsanitize=undefined' LDFLAGS='-fsanitize=undefined' sh configure
```

```
:18446744073709551616<enter>
```

Shoutout to [@c3h2_ctf](https://twitter.com/c3h2_ctf)