### PR TITLE
Fix regression where lastmark isn't saved

### DIFF
--- a/main.c
+++ b/main.c
@@ -411,7 +411,6 @@ quit(status)
 	rstat('Q');
 #endif /*LESSTEST*/
 	quitting = 1;
-	save_cmdhist();
 	if (interactive())
 		clear_bot();
 	deinit();
@@ -428,6 +427,7 @@ quit(status)
 		flush();
 	}
 	edit((char*)NULL);
+	save_cmdhist();
 	raw_mode(0);
 #if MSDOS_COMPILER && MSDOS_COMPILER != DJGPPC
 	/* 


### PR DESCRIPTION
We should be calling save_cmdhist() after edit() otherwise lastmarks
don't get saved.

Signed-off-by: William Casarin <jb55@jb55.com>
Fixes: d081e3e79b2e731fa9144d51a85abc26dad79d50 ('Add --redraw-on-quit option.')