### PR TITLE
Prevent bin_file() -> is_utf8_well_formed() buffer overrun

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -477,7 +477,7 @@ bin_file(f)
 	edata = &data[n];
 	for (p = data;  p < edata;  )
 	{
-		if (utf_mode && !is_utf8_well_formed(p, edata-data))
+		if (utf_mode && !is_utf8_well_formed(p, edata-p))
 		{
 			bin_count++;
 			utf_skip_to_lead(&p, edata);


### PR DESCRIPTION
When supplied with a file of random data >256 bytes, read()
would return a full buffer of data[256] to bin_file().
That function loops through the buffer, but calls is_utf8_well_formed()
with the full length of the buffer.  When looping on the last byte of the
buffer, is_uft8_well_formed() reads past the end.

This commit fixes bin_file() to only inspect the remaining bytes in the
buffer.

Found and tested with CheriBSD on an Arm Morello platform running with strong
memory safety.

Example file of random data 'rand' attached (zipped), sha256sum:
`a1419d3bcf8702b825a5a565a49ded104d5df3f04995244c06cd41430f5d6cf7  rand`
[rand.zip](https://github.com/gwsw/less/files/8950330/rand.zip)
