### PR TITLE
fix defines.h include order

### DIFF
--- a/lesskey.c
+++ b/lesskey.c
@@ -80,12 +80,12 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * 
  */
 
+#include "defines.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include "lesskey.h"
 #include "cmd.h"
-#include "defines.h"
 
 char fileheader[] = {
 	C0_LESSKEY_MAGIC, 

--- a/lesskey_parse.c
+++ b/lesskey_parse.c
@@ -7,13 +7,13 @@
  * For more information, see the README file.
  */
 
+#include "defines.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 #include "lesskey.h"
 #include "cmd.h"
 #include "xbuf.h"
-#include "defines.h"
 
 #define CONTROL(c)      ((c)&037)
 #define ESC             CONTROL('[')


### PR DESCRIPTION
The defines.h header sets up defines that the C library relies on. By including it *after* C library headers, those defines end up not having any effect.  Move them to the first include in these files to fix.

More specifically, the LFS flags (_FILE_OFFSET_BITS) are ignored by glibc unless they are defined before glibc headers are included. This fixes LFS support in the lesskey parsing logic.