### PR TITLE
Fix cfi-icall violations

### DIFF
--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -1563,7 +1563,7 @@ read_cmdhist(action, uparam, skip_search, skip_shell)
 addhist_init(uparam, ml, string)
 	void *uparam;
 	struct mlist *ml;
-	char constant *string;
+	char *string;
 {
 	if (ml != NULL)
 		cmd_addhist(ml, string, 0);
@@ -1648,7 +1648,7 @@ struct save_ctx
 copy_hist(uparam, ml, string)
 	void *uparam;
 	struct mlist *ml;
-	char constant *string;
+	char *string;
 {
 	struct save_ctx *ctx = (struct save_ctx *) uparam;
 


### PR DESCRIPTION
Using the 'constant' attribute causes a cfi-icall violation since the function pointer uses only 'char *'.

Signed-off-by:	Shawn Webb <shawn.webb@hardenedbsd.org>