### PR TITLE
Fix signal race in iread.

### DIFF
--- a/os.c
+++ b/os.c
@@ -119,7 +119,7 @@ start:
 	}
 #endif
 #endif
-	if (SET_JUMP(read_label))
+	if (!reading && SET_JUMP(read_label))
 	{
 		/*
 		 * We jumped here from intread.


### PR DESCRIPTION
The _setjmp call may be half-through with its operation when it is interrupted by _longjmp. This can happen if iread() reaches line 172 which calls getchr, which in itself can call iread() again.

Effectively, it means that "reading" is already 1 when SET_JUMP is called. A badly timed SIGINT could therefore mix up register states and stack pointers of two different situations.

It can be reliably reproduced by using tmux and entering ":send-keys F C-x" to quickly send F and CTRL+x to less.

My tests on Linux/amd64 did not reveal a way to crash less or do worse stuff, but let's be safe than sorry.

The fix is quite simple: Do not call SET_JUMP from within nested iread calls. If reading is already 1, keep the read_label as it is.