### PR TITLE
Update function definitions to ANSI style

### DIFF
--- a/brac.c
+++ b/brac.c
@@ -23,12 +23,8 @@
  * The characters which serve as "open bracket" and 
  * "close bracket" are given.
  */
-	public void
-match_brac(obrac, cbrac, forwdir, n)
-	int obrac;
-	int cbrac;
-	int forwdir;
-	int n;
+	public void 
+match_brac(int obrac, int cbrac, int forwdir, int n)
 {
 	int c;
 	int nest;

--- a/ch.c
+++ b/ch.c
@@ -362,9 +362,8 @@ ch_get(VOID_PARAM)
  * ch_ungetchar is a rather kludgy and limited way to push 
  * a single char onto an input file descriptor.
  */
-	public void
-ch_ungetchar(c)
-	int c;
+	public void 
+ch_ungetchar(int c)
 {
 	if (c != -1 && ch_ungotchar != -1)
 		error("ch_ungetchar overrun", NULL_PARG);
@@ -439,9 +438,8 @@ sync_logfile(VOID_PARAM)
 /*
  * Determine if a specific block is currently in one of the buffers.
  */
-	static int
-buffered(block)
-	BLOCKNUM block;
+	static int 
+buffered(BLOCKNUM block)
 {
 	struct buf *bp;
 	struct bufnode *bn;
@@ -461,9 +459,8 @@ buffered(block)
  * Seek to a specified position in the file.
  * Return 0 if successful, non-zero if can't seek there.
  */
-	public int
-ch_seek(pos)
-	POSITION pos;
+	public int 
+ch_seek(POSITION pos)
 {
 	BLOCKNUM new_block;
 	POSITION len;
@@ -661,9 +658,8 @@ ch_back_get(VOID_PARAM)
  * Set max amount of buffer space.
  * bufspace is in units of 1024 bytes.  -1 mean no limit.
  */
-	public void
-ch_setbufspace(bufspace)
-	int bufspace;
+	public void 
+ch_setbufspace(int bufspace)
 {
 	if (bufspace < 0)
 		maxbufs = -1;
@@ -810,9 +806,8 @@ ch_delbufs(VOID_PARAM)
 /*
  * Is it possible to seek on a file descriptor?
  */
-	public int
-seekable(f)
-	int f;
+	public int 
+seekable(int f)
 {
 #if MSDOS_COMPILER
 	extern int fd0;
@@ -843,10 +838,8 @@ ch_set_eof(VOID_PARAM)
 /*
  * Initialize file state for a new file.
  */
-	public void
-ch_init(f, flags)
-	int f;
-	int flags;
+	public void 
+ch_init(int f, int flags)
 {
 	/*
 	 * See if we already have a filestate for this file.

--- a/charset.c
+++ b/charset.c
@@ -136,10 +136,8 @@ static struct wchar_range_table user_prt_table;
 /*
  * Set a wchar_range_table to the table in an xbuffer.
  */
-	static void
-wchar_range_table_set(tbl, arr)
-	struct wchar_range_table *tbl;
-	struct xbuffer *arr;
+	static void 
+wchar_range_table_set(struct wchar_range_table *tbl, struct xbuffer *arr)
 {
 	tbl->table = (struct wchar_range *) arr->data;
 	tbl->count = arr->end / sizeof(struct wchar_range);
@@ -149,8 +147,7 @@ wchar_range_table_set(tbl, arr)
  * Skip over a "U" or "U+" prefix before a hex codepoint.
  */
 	static char *
-skip_uprefix(s)
-	char *s;
+skip_uprefix(char *s)
 {
 	if (*s == 'U' || *s == 'u')
 		if (*++s == '+') ++s;
@@ -160,10 +157,8 @@ skip_uprefix(s)
 /*
  * Parse a dash-separated range of hex values.
  */
-	static void
-wchar_range_get(ss, range)
-	char **ss;
-	struct wchar_range *range;
+	static void 
+wchar_range_get(char **ss, struct wchar_range *range)
 {
 	char *s = skip_uprefix(*ss);
 	range->first = lstrtoul(s, &s, 16);
@@ -181,9 +176,8 @@ wchar_range_get(ss, range)
 /*
  * Parse the LESSUTFCHARDEF variable.
  */
-	static void
-ichardef_utf(s)
-	char *s;
+	static void 
+ichardef_utf(char *s)
 {
 	xbuf_init(&user_wide_array);
 	xbuf_init(&user_ubin_array);
@@ -251,9 +245,8 @@ ichardef_utf(s)
  *      b binary character
  *      c control character
  */
-	static void
-ichardef(s)
-	char *s;
+	static void 
+ichardef(char *s)
 {
 	char *cp;
 	int n;
@@ -308,10 +301,8 @@ ichardef(s)
  * Define a charset, given a charset name.
  * The valid charset names are listed in the "charsets" array.
  */
-	static int
-icharset(name, no_error)
-	char *name;
-	int no_error;
+	static int 
+icharset(char *name, int no_error)
 {
 	struct charset *p;
 	struct cs_alias *a;
@@ -377,12 +368,8 @@ ilocale(VOID_PARAM)
 /*
  * Define the printing format for control (or binary utf) chars.
  */
-	public void
-setfmt(s, fmtvarptr, attrptr, default_fmt)
-	char *s;
-	char **fmtvarptr;
-	int *attrptr;
-	char *default_fmt;
+	public void 
+setfmt(char *s, char **fmtvarptr, int *attrptr, char *default_fmt)
 {
 	if (s && utf_mode)
 	{
@@ -531,9 +518,8 @@ init_charset(VOID_PARAM)
 /*
  * Is a given character a "binary" character?
  */
-	public int
-binary_char(c)
-	LWCHAR c;
+	public int 
+binary_char(LWCHAR c)
 {
 	if (utf_mode)
 		return (is_ubin_char(c));
@@ -544,9 +530,8 @@ binary_char(c)
 /*
  * Is a given character a "control" character?
  */
-	public int
-control_char(c)
-	LWCHAR c;
+	public int 
+control_char(LWCHAR c)
 {
 	c &= 0377;
 	return (chardef[c] & IS_CONTROL_CHAR);
@@ -557,8 +542,7 @@ control_char(c)
  * For example, in the "ascii" charset '\3' is printed as "^C".
  */
 	public char *
-prchar(c)
-	LWCHAR c;
+prchar(LWCHAR c)
 {
 	/* {{ This buffer can be overrun if LESSBINFMT is a long string. }} */
 	static char buf[MAX_PRCHAR_LEN+1];
@@ -593,8 +577,7 @@ prchar(c)
  * Return the printable form of a UTF-8 character.
  */
 	public char *
-prutfchar(ch)
-	LWCHAR ch;
+prutfchar(LWCHAR ch)
 {
 	static char buf[MAX_PRCHAR_LEN+1];
 
@@ -623,9 +606,8 @@ prutfchar(ch)
 /*
  * Get the length of a UTF-8 character in bytes.
  */
-	public int
-utf_len(ch)
-	int ch;
+	public int 
+utf_len(int ch)
 {
 	if ((ch & 0x80) == 0)
 		return 1;
@@ -646,10 +628,8 @@ utf_len(ch)
 /*
  * Does the parameter point to the lead byte of a well-formed UTF-8 character?
  */
-	public int
-is_utf8_well_formed(ss, slen)
-	char *ss;
-	int slen;
+	public int 
+is_utf8_well_formed(char *ss, int slen)
 {
 	int i;
 	int len;
@@ -684,10 +664,8 @@ is_utf8_well_formed(ss, slen)
 /*
  * Skip bytes until a UTF-8 lead byte (11xxxxxx) or ASCII byte (0xxxxxxx) is found.
  */
-	public void
-utf_skip_to_lead(pp, limit)
-	char **pp;
-	char *limit;
+	public void 
+utf_skip_to_lead(char **pp, char *limit)
 {
 	do {
 		++(*pp);
@@ -698,9 +676,8 @@ utf_skip_to_lead(pp, limit)
 /*
  * Get the value of a UTF-8 character.
  */
-	public LWCHAR
-get_wchar(p)
-	constant char *p;
+	public LWCHAR 
+get_wchar(constant char *p)
 {
 	switch (utf_len(p[0]))
 	{
@@ -750,10 +727,8 @@ get_wchar(p)
 /*
  * Store a character into a UTF-8 string.
  */
-	public void
-put_wchar(pp, ch)
-	char **pp;
-	LWCHAR ch;
+	public void 
+put_wchar(char **pp, LWCHAR ch)
 {
 	if (!utf_mode || ch < 0x80) 
 	{
@@ -800,11 +775,8 @@ put_wchar(pp, ch)
 /*
  * Step forward or backward one character in a string.
  */
-	public LWCHAR
-step_char(pp, dir, limit)
-	char **pp;
-	signed int dir;
-	constant char *limit;
+	public LWCHAR 
+step_char(char **pp, signed int dir, constant char *limit)
 {
 	LWCHAR ch;
 	int len;
@@ -874,10 +846,8 @@ static struct wchar_range comb_table[] = {
 };
 
 
-	static int
-is_in_table(ch, table)
-	LWCHAR ch;
-	struct wchar_range_table *table;
+	static int 
+is_in_table(LWCHAR ch, struct wchar_range_table *table)
 {
 	int hi;
 	int lo;
@@ -904,9 +874,8 @@ is_in_table(ch, table)
  * Is a character a UTF-8 composing character?
  * If a composing character follows any char, the two combine into one glyph.
  */
-	public int
-is_composing_char(ch)
-	LWCHAR ch;
+	public int 
+is_composing_char(LWCHAR ch)
 {
 	if (is_in_table(ch, &user_prt_table)) return 0;
 	return is_in_table(ch, &user_compose_table) ||
@@ -917,9 +886,8 @@ is_composing_char(ch)
 /*
  * Should this UTF-8 character be treated as binary?
  */
-	public int
-is_ubin_char(ch)
-	LWCHAR ch;
+	public int 
+is_ubin_char(LWCHAR ch)
 {
 	if (is_in_table(ch, &user_prt_table)) return 0;
 	return is_in_table(ch, &user_ubin_table) ||
@@ -930,9 +898,8 @@ is_ubin_char(ch)
 /*
  * Is this a double width UTF-8 character?
  */
-	public int
-is_wide_char(ch)
-	LWCHAR ch;
+	public int 
+is_wide_char(LWCHAR ch)
 {
 	return is_in_table(ch, &user_wide_table) ||
 	       is_in_table(ch, &wide_table);
@@ -943,10 +910,8 @@ is_wide_char(ch)
  * A combining char acts like an ordinary char, but if it follows
  * a specific char (not any char), the two combine into one glyph.
  */
-	public int
-is_combining_char(ch1, ch2)
-	LWCHAR ch1;
-	LWCHAR ch2;
+	public int 
+is_combining_char(LWCHAR ch1, LWCHAR ch2)
 {
 	/* The table is small; use linear search. */
 	int i;

--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -143,9 +143,8 @@ clear_cmd(VOID_PARAM)
 /*
  * Display a string, usually as a prompt for input into the command buffer.
  */
-	public void
-cmd_putstr(s)
-	constant char *s;
+	public void 
+cmd_putstr(constant char *s)
 {
 	LWCHAR prev_ch = 0;
 	LWCHAR ch;
@@ -193,12 +192,7 @@ len_cmdbuf(VOID_PARAM)
  *    since they're always the same. Maybe clean this up someday. }}
  */
 	static char *
-cmd_step_common(p, ch, len, pwidth, bswidth)
-	char *p;
-	LWCHAR ch;
-	int len;
-	int *pwidth;
-	int *bswidth;
+cmd_step_common(char *p, LWCHAR ch, int len, int *pwidth, int *bswidth)
 {
 	char *pr;
 	int width;
@@ -234,10 +228,7 @@ cmd_step_common(p, ch, len, pwidth, bswidth)
  * Step a pointer one character right in the command buffer.
  */
 	static char *
-cmd_step_right(pp, pwidth, bswidth)
-	char **pp;
-	int *pwidth;
-	int *bswidth;
+cmd_step_right(char **pp, int *pwidth, int *bswidth)
 {
 	char *p = *pp;
 	LWCHAR ch = step_char(pp, +1, p + strlen(p));
@@ -249,10 +240,7 @@ cmd_step_right(pp, pwidth, bswidth)
  * Step a pointer one character left in the command buffer.
  */
 	static char *
-cmd_step_left(pp, pwidth, bswidth)
-	char **pp;
-	int *pwidth;
-	int *bswidth;
+cmd_step_left(char **pp, int *pwidth, int *bswidth)
 {
 	char *p = *pp;
 	LWCHAR ch = step_char(pp, -1, cmdbuf);
@@ -284,9 +272,8 @@ cmd_home(VOID_PARAM)
  * Repaint the line from cp onwards.
  * Then position the cursor just after the char old_cp (a pointer into cmdbuf).
  */
-	public void
-cmd_repaint(old_cp)
-	constant char *old_cp;
+	public void 
+cmd_repaint(constant char *old_cp)
 {
 	/*
 	 * Repaint the line from the current position.
@@ -463,10 +450,8 @@ cmd_left(VOID_PARAM)
 /*
  * Insert a char into the command buffer, at the current position.
  */
-	static int
-cmd_ichar(cs, clen)
-	char *cs;
-	int clen;
+	static int 
+cmd_ichar(char *cs, int clen)
 {
 	char *s;
 	
@@ -646,10 +631,8 @@ cmd_kill(VOID_PARAM)
 /*
  * Select an mlist structure to be the current command history.
  */
-	public void
-set_mlist(mlist, cmdflags)
-	void *mlist;
-	int cmdflags;
+	public void 
+set_mlist(void *mlist, int cmdflags)
 {
 #if CMD_HISTORY
 	curr_mlist = (struct mlist *) mlist;
@@ -667,9 +650,8 @@ set_mlist(mlist, cmdflags)
  * Only consider entries whose first updown_match chars are equal to
  * cmdbuf's corresponding chars.
  */
-	static int
-cmd_updown(action)
-	int action;
+	static int 
+cmd_updown(int action)
 {
 	constant char *s;
 	struct mlist *ml;
@@ -731,10 +713,8 @@ cmd_updown(action)
 /*
  *
  */
-	static void
-ml_link(mlist, ml)
-	struct mlist *mlist;
-	struct mlist *ml;
+	static void 
+ml_link(struct mlist *mlist, struct mlist *ml)
 {
 	ml->next = mlist;
 	ml->prev = mlist->prev;
@@ -745,9 +725,8 @@ ml_link(mlist, ml)
 /*
  *
  */
-	static void
-ml_unlink(ml)
-	struct mlist *ml;
+	static void 
+ml_unlink(struct mlist *ml)
 {
 	ml->prev->next = ml->next;
 	ml->next->prev = ml->prev;
@@ -756,11 +735,8 @@ ml_unlink(ml)
 /*
  * Add a string to an mlist.
  */
-	public void
-cmd_addhist(mlist, cmd, modified)
-	struct mlist *mlist;
-	constant char *cmd;
-	int modified;
+	public void 
+cmd_addhist(struct mlist *mlist, constant char *cmd, int modified)
 {
 #if CMD_HISTORY
 	struct mlist *ml;
@@ -836,9 +812,8 @@ cmd_accept(VOID_PARAM)
  *      CC_OK   Line edit function done.
  *      CC_QUIT The char requests the current command to be aborted.
  */
-	static int
-cmd_edit(c)
-	int c;
+	static int 
+cmd_edit(int c)
 {
 	int action;
 	int flags;
@@ -953,9 +928,8 @@ cmd_edit(c)
 /*
  * Insert a string into the command buffer, at the current position.
  */
-	static int
-cmd_istr(str)
-	char *str;
+	static int 
+cmd_istr(char *str)
 {
 	char *s;
 	int action;
@@ -1129,9 +1103,7 @@ init_compl(VOID_PARAM)
  * Return the next word in the current completion list.
  */
 	static char *
-next_compl(action, prev)
-	int action;
-	char *prev;
+next_compl(int action, char *prev)
 {
 	switch (action)
 	{
@@ -1150,9 +1122,8 @@ next_compl(action, prev)
  * remembers whether this call is the first time (create the list),
  * or a subsequent time (step thru the list).
  */
-	static int
-cmd_complete(action)
-	int action;
+	static int 
+cmd_complete(int action)
 {
 	char *s;
 
@@ -1248,9 +1219,8 @@ fail:
  *      CC_QUIT         The char requests the command to be aborted.
  *      CC_ERROR        The char could not be accepted due to an error.
  */
-	public int
-cmd_char(c)
-	int c;
+	public int 
+cmd_char(int c)
 {
 	int action;
 	int len;
@@ -1345,9 +1315,8 @@ cmd_char(c)
 /*
  * Return the number currently in the command buffer.
  */
-	public LINENUM
-cmd_int(frac)
-	long *frac;
+	public LINENUM 
+cmd_int(long *frac)
 {
 	char *p;
 	LINENUM n = 0;
@@ -1400,9 +1369,8 @@ cmd_lastpattern(VOID_PARAM)
 #if CMD_HISTORY
 /*
  */
-	static int
-mlist_size(ml)
-	struct mlist *ml;
+	static int 
+mlist_size(struct mlist *ml)
 {
 	int size = 0;
 	for (ml = ml->next;  ml->string != NULL;  ml = ml->next)
@@ -1414,8 +1382,7 @@ mlist_size(ml)
  * Get the name of the history file.
  */
 	static char *
-histfile_find(must_exist)
-	int must_exist;
+histfile_find(int must_exist)
 {
 	char *home = lgetenv("HOME");
 	char *name = NULL;
@@ -1443,8 +1410,7 @@ histfile_find(must_exist)
 }
 
 	static char *
-histfile_name(must_exist)
-	int must_exist;
+histfile_name(int must_exist)
 {
 	char *name;
 
@@ -1476,12 +1442,8 @@ histfile_name(must_exist)
 /*
  * Read a .lesshst file and call a callback for each line in the file.
  */
-	static void
-read_cmdhist2(action, uparam, skip_search, skip_shell)
-	void (*action)(void*,struct mlist*,char*);
-	void *uparam;
-	int skip_search;
-	int skip_shell;
+	static void 
+read_cmdhist2(void (*action)(void *, struct mlist *, char *), void *uparam, int skip_search, int skip_shell)
 {
 	struct mlist *ml = NULL;
 	char line[CMDBUF_SIZE];
@@ -1546,12 +1508,8 @@ read_cmdhist2(action, uparam, skip_search, skip_shell)
 	fclose(f);
 }
 
-	static void
-read_cmdhist(action, uparam, skip_search, skip_shell)
-	void (*action)(void*,struct mlist*,char*);
-	void *uparam;
-	int skip_search;
-	int skip_shell;
+	static void 
+read_cmdhist(void (*action)(void *, struct mlist *, char *), void *uparam, int skip_search, int skip_shell)
 {
 	if (secure)
 		return;
@@ -1559,11 +1517,8 @@ read_cmdhist(action, uparam, skip_search, skip_shell)
 	(*action)(uparam, NULL, NULL); /* signal end of file */
 }
 
-	static void
-addhist_init(uparam, ml, string)
-	void *uparam;
-	struct mlist *ml;
-	char *string;
+	static void 
+addhist_init(void *uparam, struct mlist *ml, char *string)
 {
 	if (ml != NULL)
 		cmd_addhist(ml, string, 0);
@@ -1587,10 +1542,8 @@ init_cmdhist(VOID_PARAM)
  * Write the header for a section of the history file.
  */
 #if CMD_HISTORY
-	static void
-write_mlist_header(ml, f)
-	struct mlist *ml;
-	FILE *f;
+	static void 
+write_mlist_header(struct mlist *ml, FILE *f)
 {
 	if (ml == &mlist_search)
 		fprintf(f, "%s\n", HISTFILE_SEARCH_SECTION);
@@ -1603,10 +1556,8 @@ write_mlist_header(ml, f)
 /*
  * Write all modified entries in an mlist to the history file.
  */
-	static void
-write_mlist(ml, f)
-	struct mlist *ml;
-	FILE *f;
+	static void 
+write_mlist(struct mlist *ml, FILE *f)
 {
 	for (ml = ml->next;  ml->string != NULL;  ml = ml->next)
 	{
@@ -1622,8 +1573,7 @@ write_mlist(ml, f)
  * Make a temp name in the same directory as filename.
  */
 	static char *
-make_tempname(filename)
-	char *filename;
+make_tempname(char *filename)
 {
 	char lastch;
 	char *tempname = ecalloc(1, strlen(filename)+1);
@@ -1644,11 +1594,8 @@ struct save_ctx
  * At the end of each mlist, append any new entries
  * created during this session.
  */
-	static void
-copy_hist(uparam, ml, string)
-	void *uparam;
-	struct mlist *ml;
-	char *string;
+	static void 
+copy_hist(void *uparam, struct mlist *ml, char *string)
 {
 	struct save_ctx *ctx = (struct save_ctx *) uparam;
 
@@ -1689,9 +1636,8 @@ copy_hist(uparam, ml, string)
 /*
  * Make a file readable only by its owner.
  */
-	static void
-make_file_private(f)
-	FILE *f;
+	static void 
+make_file_private(FILE *f)
 {
 #if HAVE_FCHMOD
 	int do_chmod = 1;

--- a/command.c
+++ b/command.c
@@ -111,9 +111,8 @@ cmd_exec(VOID_PARAM)
 /*
  * Indicate we are reading a multi-character command.
  */
-	static void
-set_mca(action)
-	int action;
+	static void 
+set_mca(int action)
 {
 	mca = action;
 	clear_bot();
@@ -134,12 +133,8 @@ clear_mca(VOID_PARAM)
 /*
  * Set up the display to start a new multi-character command.
  */
-	static void
-start_mca(action, prompt, mlist, cmdflags)
-	int action;
-	constant char *prompt;
-	void *mlist;
-	int cmdflags;
+	static void 
+start_mca(int action, constant char *prompt, void *mlist, int cmdflags)
 {
 	set_mca(action);
 	cmd_putstr(prompt);
@@ -328,9 +323,8 @@ exec_mca(VOID_PARAM)
 /*
  * Is a character an erase or kill char?
  */
-	static int
-is_erase_char(c)
-	int c;
+	static int 
+is_erase_char(int c)
 {
 	return (c == erase_char || c == erase2_char || c == kill_char);
 }
@@ -338,9 +332,8 @@ is_erase_char(c)
 /*
  * Is a character a carriage return or newline?
  */
-	static int
-is_newline_char(c)
-	int c;
+	static int 
+is_newline_char(int c)
 {
 	return (c == '\n' || c == '\r');
 }
@@ -348,9 +341,8 @@ is_newline_char(c)
 /*
  * Handle the first char of an option (after the initial dash).
  */
-	static int
-mca_opt_first_char(c)
-	int c;
+	static int 
+mca_opt_first_char(int c)
 {
 	int no_prompt = (optflag & OPT_NO_PROMPT);
 	int flag = (optflag & ~OPT_NO_PROMPT);
@@ -401,9 +393,8 @@ mca_opt_first_char(c)
  * If so, display the complete name and stop 
  * accepting chars until user hits RETURN.
  */
-	static int
-mca_opt_nonfirst_char(c)
-	int c;
+	static int 
+mca_opt_nonfirst_char(int c)
 {
 	char *p;
 	char *oname;
@@ -458,9 +449,8 @@ mca_opt_nonfirst_char(c)
 /*
  * Handle a char of an option toggle command.
  */
-	static int
-mca_opt_char(c)
-	int c;
+	static int 
+mca_opt_char(int c)
 {
 	PARG parg;
 
@@ -527,9 +517,8 @@ mca_opt_char(c)
 /*
  * Normalize search type.
  */
-	public int
-norm_search_type(st)
-	int st;
+	public int 
+norm_search_type(int st)
 {
 	/* WRAP and PAST_EOF are mutually exclusive. */
 	if ((st & (SRCH_PAST_EOF|SRCH_WRAP)) == (SRCH_PAST_EOF|SRCH_WRAP))
@@ -540,9 +529,8 @@ norm_search_type(st)
 /*
  * Handle a char of a search command.
  */
-	static int
-mca_search_char(c)
-	int c;
+	static int 
+mca_search_char(int c)
 {
 	int flag = 0;
 
@@ -597,9 +585,8 @@ mca_search_char(c)
 /*
  * Handle a character of a multi-character command.
  */
-	static int
-mca_char(c)
-	int c;
+	static int 
+mca_char(int c)
 {
 	int ret;
 
@@ -957,12 +944,8 @@ getccu(VOID_PARAM)
  * Get a command character, but if we receive the orig sequence,
  * convert it to the repl sequence.
  */
-	static LWCHAR
-getcc_repl(orig, repl, gr_getc, gr_ungetc)
-	char constant* orig;
-	char constant* repl;
-	LWCHAR (*gr_getc)(VOID_PARAM);
-	void (*gr_ungetc)(LWCHAR);
+	static LWCHAR 
+getcc_repl(char constant *orig, char constant *repl, LWCHAR (*gr_getc)(VOID_PARAM), void (*gr_ungetc)(LWCHAR))
 {
 	LWCHAR c;
 	LWCHAR keys[16];
@@ -1012,9 +995,8 @@ getcc(VOID_PARAM)
  * "Unget" a command character.
  * The next getcc() will return this character.
  */
-	public void
-ungetcc(c)
-	LWCHAR c;
+	public void 
+ungetcc(LWCHAR c)
 {
 	struct ungot *ug = (struct ungot *) ecalloc(1, sizeof(struct ungot));
 
@@ -1027,9 +1009,8 @@ ungetcc(c)
  * "Unget" a command character.
  * If any other chars are already ungotten, put this one after those.
  */
-	public void
-ungetcc_back(c)
-	LWCHAR c;
+	public void 
+ungetcc_back(LWCHAR c)
 {
 	struct ungot *ug = (struct ungot *) ecalloc(1, sizeof(struct ungot));
 	ug->ug_char = c;
@@ -1049,9 +1030,8 @@ ungetcc_back(c)
  * Unget a whole string of command characters.
  * The next sequence of getcc()'s will return this string.
  */
-	public void
-ungetsc(s)
-	char *s;
+	public void 
+ungetsc(char *s)
 {
 	while (*s != '\0')
 		ungetcc_back(*s++);
@@ -1073,11 +1053,8 @@ peekcc(VOID_PARAM)
  * If SRCH_FIRST_FILE is set, begin searching at the first file.
  * If SRCH_PAST_EOF is set, continue the search thru multiple files.
  */
-	static void
-multi_search(pattern, n, silent)
-	char *pattern;
-	int n;
-	int silent;
+	static void 
+multi_search(char *pattern, int n, int silent)
 {
 	int nomore;
 	IFILE save_ifile;
@@ -1171,9 +1148,8 @@ multi_search(pattern, n, silent)
 /*
  * Forward forever, or until a highlighted line appears.
  */
-	static int
-forw_loop(until_hilite)
-	int until_hilite;
+	static int 
+forw_loop(int until_hilite)
 {
 	POSITION curr_len;
 

--- a/cvt.c
+++ b/cvt.c
@@ -19,10 +19,8 @@ extern int utf_mode;
 /*
  * Get the length of a buffer needed to convert a string.
  */
-	public int
-cvt_length(len, ops)
-	int len;
-	int ops;
+	public int 
+cvt_length(int len, int ops)
 {
 	if (utf_mode)
 		/*
@@ -38,8 +36,7 @@ cvt_length(len, ops)
  * Allocate a chpos array for use by cvt_text.
  */
 	public int *
-cvt_alloc_chpos(len)
-	int len;
+cvt_alloc_chpos(int len)
 {
 	int i;
 	int *chpos = (int *) ecalloc(sizeof(int), len);
@@ -54,13 +51,8 @@ cvt_alloc_chpos(len)
  * Returns converted text in odst.  The original offset of each
  * odst character (when it was in osrc) is returned in the chpos array.
  */
-	public void
-cvt_text(odst, osrc, chpos, lenp, ops)
-	char *odst;
-	char *osrc;
-	int *chpos;
-	int *lenp;
-	int ops;
+	public void 
+cvt_text(char *odst, char *osrc, int *chpos, int *lenp, int ops)
 {
 	char *dst;
 	char *edst = odst;

--- a/decode.c
+++ b/decode.c
@@ -242,10 +242,8 @@ static struct tablelist *list_sysvar_tables = NULL;
 /*
  * Expand special key abbreviations in a command table.
  */
-	static void
-expand_special_keys(table, len)
-	char *table;
-	int len;
+	static void 
+expand_special_keys(char *table, int len)
 {
 	char *fm;
 	char *to;
@@ -303,9 +301,8 @@ expand_special_keys(table, len)
 /*
  * Expand special key abbreviations in a list of command tables.
  */
-	static void
-expand_cmd_table(tlist)
-	struct tablelist *tlist;
+	static void 
+expand_cmd_table(struct tablelist *tlist)
 {
 	struct tablelist *t;
 	for (t = tlist;  t != NULL;  t = t->t_next)
@@ -380,11 +377,8 @@ init_cmds(VOID_PARAM)
 /*
  * Add a command table.
  */
-	static int
-add_cmd_table(tlist, buf, len)
-	struct tablelist **tlist;
-	char *buf;
-	int len;
+	static int 
+add_cmd_table(struct tablelist **tlist, char *buf, int len)
 {
 	struct tablelist *t;
 
@@ -409,10 +403,8 @@ add_cmd_table(tlist, buf, len)
 /*
  * Add a command table.
  */
-	public void
-add_fcmd_table(buf, len)
-	char *buf;
-	int len;
+	public void 
+add_fcmd_table(char *buf, int len)
 {
 	if (add_cmd_table(&list_fcmd_tables, buf, len) < 0)
 		error("Warning: some commands disabled", NULL_PARG);
@@ -421,10 +413,8 @@ add_fcmd_table(buf, len)
 /*
  * Add an editing command table.
  */
-	public void
-add_ecmd_table(buf, len)
-	char *buf;
-	int len;
+	public void 
+add_ecmd_table(char *buf, int len)
 {
 	if (add_cmd_table(&list_ecmd_tables, buf, len) < 0)
 		error("Warning: some edit commands disabled", NULL_PARG);
@@ -433,11 +423,8 @@ add_ecmd_table(buf, len)
 /*
  * Add an environment variable table.
  */
-	static void
-add_var_table(tlist, buf, len)
-	struct tablelist **tlist;
-	char *buf;
-	int len;
+	static void 
+add_var_table(struct tablelist **tlist, char *buf, int len)
 {
 	if (add_cmd_table(tlist, buf, len) < 0)
 		error("Warning: environment variables from lesskey file unavailable", NULL_PARG);
@@ -464,10 +451,8 @@ mouse_wheel_up(VOID_PARAM)
 /*
  * Return action for a mouse button release event.
  */
-	static int
-mouse_button_rel(x, y)
-	int x;
-	int y;
+	static int 
+mouse_button_rel(int x, int y)
 {
 	/*
 	 * {{ It would be better to return an action and then do this 
@@ -484,9 +469,8 @@ mouse_button_rel(x, y)
 /*
  * Read a decimal integer. Return the integer and set *pterm to the terminating char.
  */
-	static int
-getcc_int(pterm)
-	char* pterm;
+	static int 
+getcc_int(char *pterm)
 {
 	int num = 0;
 	int digits = 0;
@@ -509,9 +493,8 @@ getcc_int(pterm)
  * Read suffix of mouse input and return the action to take.
  * The prefix ("\e[M") has already been read.
  */
-	static int
-x11mouse_action(skip)
-	int skip;
+	static int 
+x11mouse_action(int skip)
 {
 	int b = getcc() - X11MOUSE_OFFSET;
 	int x = getcc() - X11MOUSE_OFFSET-1;
@@ -534,9 +517,8 @@ x11mouse_action(skip)
  * Read suffix of mouse input and return the action to take.
  * The prefix ("\e[<") has already been read.
  */
-	static int
-x116mouse_action(skip)
-	int skip;
+	static int 
+x116mouse_action(int skip)
 {
 	char ch;
 	int x, y;
@@ -562,12 +544,8 @@ x116mouse_action(skip)
 /*
  * Search a single command table for the command string in cmd.
  */
-	static int
-cmd_search(cmd, table, endtable, sp)
-	char *cmd;
-	char *table;
-	char *endtable;
-	char **sp;
+	static int 
+cmd_search(char *cmd, char *table, char *endtable, char **sp)
 {
 	char *p;
 	char *q;
@@ -658,11 +636,8 @@ cmd_search(cmd, table, endtable, sp)
  * Decode a command character and return the associated action.
  * The "extra" string, if any, is returned in sp.
  */
-	static int
-cmd_decode(tlist, cmd, sp)
-	struct tablelist *tlist;
-	char *cmd;
-	char **sp;
+	static int 
+cmd_decode(struct tablelist *tlist, char *cmd, char **sp)
 {
 	struct tablelist *t;
 	int action = A_INVALID;
@@ -685,10 +660,8 @@ cmd_decode(tlist, cmd, sp)
 /*
  * Decode a command from the cmdtables list.
  */
-	public int
-fcmd_decode(cmd, sp)
-	char *cmd;
-	char **sp;
+	public int 
+fcmd_decode(char *cmd, char **sp)
 {
 	return (cmd_decode(list_fcmd_tables, cmd, sp));
 }
@@ -696,10 +669,8 @@ fcmd_decode(cmd, sp)
 /*
  * Decode a command from the edittables list.
  */
-	public int
-ecmd_decode(cmd, sp)
-	char *cmd;
-	char **sp;
+	public int 
+ecmd_decode(char *cmd, char **sp)
 {
 	return (cmd_decode(list_ecmd_tables, cmd, sp));
 }
@@ -709,8 +680,7 @@ ecmd_decode(cmd, sp)
  * Looks first in the lesskey file, then in the real environment.
  */
 	public char *
-lgetenv(var)
-	char *var;
+lgetenv(char *var)
 {
 	int a;
 	char *s;
@@ -730,9 +700,8 @@ lgetenv(var)
 /*
  * Is a string null or empty? 
  */
-	public int
-isnullenv(s)
-	char* s;
+	public int 
+isnullenv(char *s)
 {
 	return (s == NULL || *s == '\0');
 }
@@ -743,9 +712,8 @@ isnullenv(s)
  * Integers are stored in a funny format: 
  * two bytes, low order first, in radix KRADIX.
  */
-	static int
-gint(sp)
-	char **sp;
+	static int 
+gint(char **sp)
 {
 	int n;
 
@@ -757,10 +725,8 @@ gint(sp)
 /*
  * Process an old (pre-v241) lesskey file.
  */
-	static int
-old_lesskey(buf, len)
-	char *buf;
-	int len;
+	static int 
+old_lesskey(char *buf, int len)
 {
 	/*
 	 * Old-style lesskey file.
@@ -778,11 +744,8 @@ old_lesskey(buf, len)
 /* 
  * Process a new (post-v241) lesskey file.
  */
-	static int
-new_lesskey(buf, len, sysvar)
-	char *buf;
-	int len;
-	int sysvar;
+	static int 
+new_lesskey(char *buf, int len, int sysvar)
 {
 	char *p;
 	char *end;
@@ -840,10 +803,8 @@ new_lesskey(buf, len, sysvar)
 /*
  * Set up a user command table, based on a "lesskey" file.
  */
-	public int
-lesskey(filename, sysvar)
-	char *filename;
-	int sysvar;
+	public int 
+lesskey(char *filename, int sysvar)
 {
 	char *buf;
 	POSITION len;
@@ -907,10 +868,8 @@ lesskey(filename, sysvar)
 }
 
 #if HAVE_LESSKEYSRC 
-	public int
-lesskey_src(filename, sysvar)
-	char *filename;
-	int sysvar;
+	public int 
+lesskey_src(char *filename, int sysvar)
 {
 	static struct lesskey_tables tables;
 	int r = parse_lesskey(filename, &tables);
@@ -923,9 +882,8 @@ lesskey_src(filename, sysvar)
 	return (0);
 }
 
-	void
-lesskey_parse_error(s)
-	char *s;
+	void 
+lesskey_parse_error(char *s)
 {
 	PARG parg;
 	parg.p_string = s;
@@ -936,12 +894,8 @@ lesskey_parse_error(s)
 /*
  * Add a lesskey file.
  */
-	public int
-add_hometable(call_lesskey, envname, def_filename, sysvar)
-	int (*call_lesskey)(char *, int);
-	char *envname;
-	char *def_filename;
-	int sysvar;
+	public int 
+add_hometable(int (*call_lesskey)(char *, int), char *envname, char *def_filename, int sysvar)
 {
 	char *filename;
 	int r;
@@ -980,10 +934,8 @@ add_hometable(call_lesskey, envname, def_filename, sysvar)
 /*
  * See if a char is a special line-editing command.
  */
-	public int
-editchar(c, flags)
-	int c;
-	int flags;
+	public int 
+editchar(int c, int flags)
 {
 	int action;
 	int nch;

--- a/edit.c
+++ b/edit.c
@@ -55,10 +55,8 @@ public ino_t curr_ino;
  * words, returning each one as a standard null-terminated string.
  * back_textlist does the same, but runs thru the list backwards.
  */
-	public void
-init_textlist(tlist, str)
-	struct textlist *tlist;
-	char *str;
+	public void 
+init_textlist(struct textlist *tlist, char *str)
 {
 	char *s;
 #if SPACES_IN_FILENAMES
@@ -100,9 +98,7 @@ init_textlist(tlist, str)
 }
 
 	public char *
-forw_textlist(tlist, prev)
-	struct textlist *tlist;
-	char *prev;
+forw_textlist(struct textlist *tlist, char *prev)
 {
 	char *s;
 	
@@ -124,9 +120,7 @@ forw_textlist(tlist, prev)
 }
 
 	public char *
-back_textlist(tlist, prev)
-	struct textlist *tlist;
-	char *prev;
+back_textlist(struct textlist *tlist, char *prev)
 {
 	char *s;
 	
@@ -223,9 +217,8 @@ close_file(VOID_PARAM)
  * Filename == "-" means standard input.
  * Filename == NULL means just close the current file.
  */
-	public int
-edit(filename)
-	char *filename;
+	public int 
+edit(char *filename)
 {
 	if (filename == NULL)
 		return (edit_ifile(NULL_IFILE));
@@ -235,13 +228,8 @@ edit(filename)
 /*
  * Clean up what edit_ifile did before error return.
  */
-	static int
-edit_error(filename, alt_filename, altpipe, ifile, was_curr_ifile)
-	char *filename;
-	char *alt_filename;
-	void *altpipe;
-	IFILE ifile;
-	IFILE was_curr_ifile;
+	static int 
+edit_error(char *filename, char *alt_filename, void *altpipe, IFILE ifile, IFILE was_curr_ifile)
 {
 	if (alt_filename != NULL)
 	{
@@ -270,9 +258,8 @@ edit_error(filename, alt_filename, altpipe, ifile, was_curr_ifile)
  * Edit a new file (given its IFILE).
  * ifile == NULL means just close the current file.
  */
-	public int
-edit_ifile(ifile)
-	IFILE ifile;
+	public int 
+edit_ifile(IFILE ifile)
 {
 	int f;
 	int answer;
@@ -522,9 +509,8 @@ edit_ifile(ifile)
  * For each filename in the list, enter it into the ifile list.
  * Then edit the first one.
  */
-	public int
-edit_list(filelist)
-	char *filelist;
+	public int 
+edit_list(char *filelist)
 {
 	IFILE save_ifile;
 	char *good_filename;
@@ -606,11 +592,8 @@ edit_last(VOID_PARAM)
 /*
  * Edit the n-th next or previous file in the command line (ifile) list.
  */
-	static int
-edit_istep(h, n, dir)
-	IFILE h;
-	int n;
-	int dir;
+	static int 
+edit_istep(IFILE h, int n, int dir)
 {
 	IFILE next;
 
@@ -648,32 +631,26 @@ edit_istep(h, n, dir)
 	return (0);
 }
 
-	static int
-edit_inext(h, n)
-	IFILE h;
-	int n;
+	static int 
+edit_inext(IFILE h, int n)
 {
 	return (edit_istep(h, n, +1));
 }
 
-	public int
-edit_next(n)
-	int n;
+	public int 
+edit_next(int n)
 {
 	return edit_istep(curr_ifile, n, +1);
 }
 
-	static int
-edit_iprev(h, n)
-	IFILE h;
-	int n;
+	static int 
+edit_iprev(IFILE h, int n)
 {
 	return (edit_istep(h, n, -1));
 }
 
-	public int
-edit_prev(n)
-	int n;
+	public int 
+edit_prev(int n)
 {
 	return edit_istep(curr_ifile, n, -1);
 }
@@ -681,9 +658,8 @@ edit_prev(n)
 /*
  * Edit a specific file in the command line (ifile) list.
  */
-	public int
-edit_index(n)
-	int n;
+	public int 
+edit_index(int n)
 {
 	IFILE h;
 
@@ -710,9 +686,8 @@ save_curr_ifile(VOID_PARAM)
 	return (curr_ifile);
 }
 
-	public void
-unsave_ifile(save_ifile)
-	IFILE save_ifile;
+	public void 
+unsave_ifile(IFILE save_ifile)
 {
 	if (save_ifile != NULL_IFILE)
 		hold_ifile(save_ifile, -1);
@@ -721,9 +696,8 @@ unsave_ifile(save_ifile)
 /*
  * Reedit the ifile which was previously open.
  */
-	public void
-reedit_ifile(save_ifile)
-	IFILE save_ifile;
+	public void 
+reedit_ifile(IFILE save_ifile)
 {
 	IFILE next;
 	IFILE prev;
@@ -800,9 +774,8 @@ cat_file(VOID_PARAM)
  * is standard input, create the log file.  
  * We take care not to blindly overwrite an existing file.
  */
-	public void
-use_logfile(filename)
-	char *filename;
+	public void 
+use_logfile(char *filename)
 {
 	int exists;
 	int answer;

--- a/filename.c
+++ b/filename.c
@@ -63,8 +63,7 @@ extern dev_t curr_dev;
  * Remove quotes around a filename.
  */
 	public char *
-shell_unquote(str)
-	char *str;
+shell_unquote(char *str)
 {
 	char *name;
 	char *p;
@@ -132,9 +131,8 @@ metachars(VOID_PARAM)
 /*
  * Is this a shell metacharacter?
  */
-	static int
-metachar(c)
-	char c;
+	static int 
+metachar(int c)
 {
 	return (strchr(metachars(), c) != NULL);
 }
@@ -143,8 +141,7 @@ metachar(c)
  * Insert a backslash before each metacharacter in a string.
  */
 	public char *
-shell_quote(s)
-	char *s;
+shell_quote(char *s)
 {
 	char *p;
 	char *newstr;
@@ -221,10 +218,7 @@ shell_quote(s)
  * Return NULL if the file does not exist in the directory.
  */
 	public char *
-dirfile(dirname, filename, must_exist)
-	char *dirname;
-	char *filename;
-	int must_exist;
+dirfile(char *dirname, char *filename, int must_exist)
 {
 	char *pathname;
 	int len;
@@ -262,8 +256,7 @@ dirfile(dirname, filename, must_exist)
  * Return the full pathname of the given file in the "home directory".
  */
 	public char *
-homefile(filename)
-	char *filename;
+homefile(char *filename)
 {
 	char *pathname;
 
@@ -306,8 +299,7 @@ homefile(filename)
  * {{ This is a lot of work just to support % and #. }}
  */
 	public char *
-fexpand(s)
-	char *s;
+fexpand(char *s)
 {
 	char *fr, *to;
 	int n;
@@ -402,8 +394,7 @@ fexpand(s)
  * the given string.
  */
 	public char *
-fcomplete(s)
-	char *s;
+fcomplete(char *s)
 {
 	char *fpat;
 	char *qs;
@@ -461,9 +452,8 @@ fcomplete(s)
  * Try to determine if a file is "binary".
  * This is just a guess, and we need not try too hard to make it accurate.
  */
-	public int
-bin_file(f)
-	int f;
+	public int 
+bin_file(int f)
 {
 	int n;
 	int bin_count = 0;
@@ -507,9 +497,8 @@ bin_file(f)
 /*
  * Try to determine the size of a file by seeking to the end.
  */
-	static POSITION
-seek_filesize(f)
-	int f;
+	static POSITION 
+seek_filesize(int f)
 {
 	off_t spos;
 
@@ -525,8 +514,7 @@ seek_filesize(f)
  * Return a pointer to the string in memory.
  */
 	static char *
-readfd(fd)
-	FILE *fd;
+readfd(FILE *fd)
 {
 	int len;
 	int ch;
@@ -568,8 +556,7 @@ readfd(fd)
  * Return a pointer to a pipe connected to the shell command's standard output.
  */
 	static FILE *
-shellcmd(cmd)
-	char *cmd;
+shellcmd(char *cmd)
 {
 	FILE *fd;
 
@@ -619,8 +606,7 @@ shellcmd(cmd)
  * Expand a filename, doing any system-specific metacharacter substitutions.
  */
 	public char *
-lglob(filename)
-	char *filename;
+lglob(char *filename)
 {
 	char *gfilename;
 
@@ -800,9 +786,8 @@ lglob(filename)
 /*
  * Does path not represent something in the file system?
  */
-	public int
-is_fake_pathname(path)
-	char *path;
+	public int 
+is_fake_pathname(char *path)
 {
 	return (strcmp(path, "-") == 0 ||
 	        strcmp(path, FAKE_HELPFILE) == 0 || strcmp(path, FAKE_EMPTYFILE) == 0);
@@ -812,8 +797,7 @@ is_fake_pathname(path)
  * Return canonical pathname.
  */
 	public char *
-lrealpath(path)
-	char *path;
+lrealpath(char *path)
 {
 	if (!is_fake_pathname(path))
 	{
@@ -831,9 +815,8 @@ lrealpath(path)
  * Return number of %s escapes in a string.
  * Return a large number if there are any other % escapes besides %s.
  */
-	static int
-num_pct_s(lessopen)
-	char *lessopen;
+	static int 
+num_pct_s(char *lessopen)
 {
 	int num = 0;
 
@@ -859,10 +842,7 @@ num_pct_s(lessopen)
  * instead of the file we're about to open.
  */
 	public char *
-open_altfile(filename, pf, pfd)
-	char *filename;
-	int *pf;
-	void **pfd;
+open_altfile(char *filename, int *pf, void **pfd)
 {
 #if !HAVE_POPEN
 	return (NULL);
@@ -983,10 +963,8 @@ open_altfile(filename, pf, pfd)
 /*
  * Close a replacement file.
  */
-	public void
-close_altfile(altfilename, filename)
-	char *altfilename;
-	char *filename;
+	public void 
+close_altfile(char *altfilename, char *filename)
 {
 #if HAVE_POPEN
 	char *lessclose;
@@ -1023,9 +1001,8 @@ close_altfile(altfilename, filename)
 /*
  * Is the specified file a directory?
  */
-	public int
-is_dir(filename)
-	char *filename;
+	public int 
+is_dir(char *filename)
 {
 	int isdir = 0;
 
@@ -1058,8 +1035,7 @@ is_dir(filename)
  * (if it cannot be opened or is a directory, etc.)
  */
 	public char *
-bad_file(filename)
-	char *filename;
+bad_file(char *filename)
 {
 	char *m = NULL;
 
@@ -1101,9 +1077,8 @@ bad_file(filename)
  * Return the size of a file, as cheaply as possible.
  * In Unix, we can stat the file.
  */
-	public POSITION
-filesize(f)
-	int f;
+	public POSITION 
+filesize(int f)
 {
 #if HAVE_STAT
 	struct stat statbuf;
@@ -1154,8 +1129,7 @@ shell_coption(VOID_PARAM)
  * Return last component of a pathname.
  */
 	public char *
-last_component(name)
-	char *name;
+last_component(char *name)
 {
 	char *slash;
 

--- a/forwback.c
+++ b/forwback.c
@@ -127,11 +127,8 @@ squish_check(VOID_PARAM)
  * Read the first pfx columns of the next line.
  * If skipeol==0 stop there, otherwise read and discard chars to end of line.
  */
-	static POSITION
-forw_line_pfx(pos, pfx, skipeol)
-	POSITION pos;
-	int pfx;
-	int skipeol;
+	static POSITION 
+forw_line_pfx(POSITION pos, int pfx, int skipeol)
 {
 	int save_sc_width = sc_width;
 	int save_auto_wrap = auto_wrap;
@@ -152,9 +149,8 @@ forw_line_pfx(pos, pfx, skipeol)
  * Underline last line of headers, but not at beginning of file
  * (where there is no gap between the last header line and the next line).
  */
-	static void
-set_attr_header(ln)
-	int ln;
+	static void 
+set_attr_header(int ln)
 {
 	set_attr_line(AT_COLOR_HEADER);
 	if (ln+1 == header_lines && position(0) != ch_zero())
@@ -220,13 +216,8 @@ overlay_header(VOID_PARAM)
  *   real line.  If nblank > 0, the pos must be NULL_POSITION.
  *   The first real line after the blanks will start at ch_zero().
  */
-	public void
-forw(n, pos, force, only_last, nblank)
-	int n;
-	POSITION pos;
-	int force;
-	int only_last;
-	int nblank;
+	public void 
+forw(int n, POSITION pos, int force, int only_last, int nblank)
 {
 	int nlines = 0;
 	int do_repaint;
@@ -410,12 +401,8 @@ forw(n, pos, force, only_last, nblank)
 /*
  * Display n lines, scrolling backward.
  */
-	public void
-back(n, pos, force, only_last)
-	int n;
-	POSITION pos;
-	int force;
-	int only_last;
+	public void 
+back(int n, POSITION pos, int force, int only_last)
 {
 	int nlines = 0;
 	int do_repaint;
@@ -474,11 +461,8 @@ back(n, pos, force, only_last)
  * Display n more lines, forward.
  * Start just after the line currently displayed at the bottom of the screen.
  */
-	public void
-forward(n, force, only_last)
-	int n;
-	int force;
-	int only_last;
+	public void 
+forward(int n, int force, int only_last)
 {
 	POSITION pos;
 
@@ -526,11 +510,8 @@ forward(n, force, only_last)
  * Display n more lines, backward.
  * Start just before the line currently displayed at the top of the screen.
  */
-	public void
-backward(n, force, only_last)
-	int n;
-	int force;
-	int only_last;
+	public void 
+backward(int n, int force, int only_last)
 {
 	POSITION pos;
 

--- a/ifile.c
+++ b/ifile.c
@@ -51,10 +51,8 @@ static struct ifile anchor = { &anchor, &anchor, NULL, NULL, NULL, 0, 0, '\0',
 				{ NULL_POSITION, 0 } };
 static int ifiles = 0;
 
-	static void
-incr_index(p, incr)
-	struct ifile *p;
-	int incr;
+	static void 
+incr_index(struct ifile *p, int incr)
 {
 	for (;  p != &anchor;  p = p->h_next)
 		p->h_index += incr;
@@ -63,10 +61,8 @@ incr_index(p, incr)
 /*
  * Link an ifile into the ifile list.
  */
-	static void
-link_ifile(p, prev)
-	struct ifile *p;
-	struct ifile *prev;
+	static void 
+link_ifile(struct ifile *p, struct ifile *prev)
 {
 	/*
 	 * Link into list.
@@ -89,9 +85,8 @@ link_ifile(p, prev)
 /*
  * Unlink an ifile from the ifile list.
  */
-	static void
-unlink_ifile(p)
-	struct ifile *p;
+	static void 
+unlink_ifile(struct ifile *p)
 {
 	p->h_next->h_prev = p->h_prev;
 	p->h_prev->h_next = p->h_next;
@@ -106,9 +101,7 @@ unlink_ifile(p)
  * Return a pointer to the new ifile structure.
  */
 	static struct ifile *
-new_ifile(filename, prev)
-	char *filename;
-	struct ifile *prev;
+new_ifile(char *filename, struct ifile *prev)
 {
 	struct ifile *p;
 
@@ -137,9 +130,8 @@ new_ifile(filename, prev)
 /*
  * Delete an existing ifile structure.
  */
-	public void
-del_ifile(h)
-	IFILE h;
+	public void 
+del_ifile(IFILE h)
 {
 	struct ifile *p;
 
@@ -162,9 +154,8 @@ del_ifile(h)
 /*
  * Get the ifile after a given one in the list.
  */
-	public IFILE
-next_ifile(h)
-	IFILE h;
+	public IFILE 
+next_ifile(IFILE h)
 {
 	struct ifile *p;
 
@@ -177,9 +168,8 @@ next_ifile(h)
 /*
  * Get the ifile before a given one in the list.
  */
-	public IFILE
-prev_ifile(h)
-	IFILE h;
+	public IFILE 
+prev_ifile(IFILE h)
 {
 	struct ifile *p;
 
@@ -192,9 +182,8 @@ prev_ifile(h)
 /*
  * Return a different ifile from the given one.
  */
-	public IFILE
-getoff_ifile(ifile)
-	IFILE ifile;
+	public IFILE 
+getoff_ifile(IFILE ifile)
 {
 	IFILE newifile;
 	
@@ -218,8 +207,7 @@ nifile(VOID_PARAM)
  * Find an ifile structure, given a filename.
  */
 	static struct ifile *
-find_ifile(filename)
-	char *filename;
+find_ifile(char *filename)
 {
 	struct ifile *p;
 	char *rfilename = lrealpath(filename);
@@ -251,10 +239,8 @@ find_ifile(filename)
  * If the filename has not been seen before,
  * insert the new ifile after "prev" in the list.
  */
-	public IFILE
-get_ifile(filename, prev)
-	char *filename;
-	IFILE prev;
+	public IFILE 
+get_ifile(char *filename, IFILE prev)
 {
 	struct ifile *p;
 
@@ -267,8 +253,7 @@ get_ifile(filename, prev)
  * Get the display filename associated with a ifile.
  */
 	public char *
-get_filename(ifile)
-	IFILE ifile;
+get_filename(IFILE ifile)
 {
 	if (ifile == NULL)
 		return (NULL);
@@ -279,8 +264,7 @@ get_filename(ifile)
  * Get the canonical filename associated with a ifile.
  */
 	public char *
-get_real_filename(ifile)
-	IFILE ifile;
+get_real_filename(IFILE ifile)
 {
 	if (ifile == NULL)
 		return (NULL);
@@ -290,9 +274,8 @@ get_real_filename(ifile)
 /*
  * Get the index of the file associated with a ifile.
  */
-	public int
-get_index(ifile)
-	IFILE ifile;
+	public int 
+get_index(IFILE ifile)
 {
 	return (int_ifile(ifile)->h_index); 
 }
@@ -300,10 +283,8 @@ get_index(ifile)
 /*
  * Save the file position to be associated with a given file.
  */
-	public void
-store_pos(ifile, scrpos)
-	IFILE ifile;
-	struct scrpos *scrpos;
+	public void 
+store_pos(IFILE ifile, struct scrpos *scrpos)
 {
 	int_ifile(ifile)->h_scrpos = *scrpos;
 }
@@ -312,10 +293,8 @@ store_pos(ifile, scrpos)
  * Recall the file position associated with a file.
  * If no position has been associated with the file, return NULL_POSITION.
  */
-	public void
-get_pos(ifile, scrpos)
-	IFILE ifile;
-	struct scrpos *scrpos;
+	public void 
+get_pos(IFILE ifile, struct scrpos *scrpos)
 {
 	*scrpos = int_ifile(ifile)->h_scrpos;
 }
@@ -323,9 +302,8 @@ get_pos(ifile, scrpos)
 /*
  * Mark the ifile as "opened".
  */
-	public void
-set_open(ifile)
-	IFILE ifile;
+	public void 
+set_open(IFILE ifile)
 {
 	int_ifile(ifile)->h_opened = 1;
 }
@@ -333,62 +311,50 @@ set_open(ifile)
 /*
  * Return whether the ifile has been opened previously.
  */
-	public int
-opened(ifile)
-	IFILE ifile;
+	public int 
+opened(IFILE ifile)
 {
 	return (int_ifile(ifile)->h_opened);
 }
 
-	public void
-hold_ifile(ifile, incr)
-	IFILE ifile;
-	int incr;
+	public void 
+hold_ifile(IFILE ifile, int incr)
 {
 	int_ifile(ifile)->h_hold += incr;
 }
 
-	public int
-held_ifile(ifile)
-	IFILE ifile;
+	public int 
+held_ifile(IFILE ifile)
 {
 	return (int_ifile(ifile)->h_hold);
 }
 
 	public void *
-get_filestate(ifile)
-	IFILE ifile;
+get_filestate(IFILE ifile)
 {
 	return (int_ifile(ifile)->h_filestate);
 }
 
-	public void
-set_filestate(ifile, filestate)
-	IFILE ifile;
-	void *filestate;
+	public void 
+set_filestate(IFILE ifile, void *filestate)
 {
 	int_ifile(ifile)->h_filestate = filestate;
 }
 
-	public void
-set_altpipe(ifile, p)
-	IFILE ifile;
-	void *p;
+	public void 
+set_altpipe(IFILE ifile, void *p)
 {
 	int_ifile(ifile)->h_altpipe = p;
 }
 
 	public void *
-get_altpipe(ifile)
-	IFILE ifile;
+get_altpipe(IFILE ifile)
 {
 	return (int_ifile(ifile)->h_altpipe);
 }
 
-	public void
-set_altfilename(ifile, altfilename)
-	IFILE ifile;
-	char *altfilename;
+	public void 
+set_altfilename(IFILE ifile, char *altfilename)
 {
 	struct ifile *p = int_ifile(ifile);
 	if (p->h_altfilename != NULL && p->h_altfilename != altfilename)
@@ -397,8 +363,7 @@ set_altfilename(ifile, altfilename)
 }
 
 	public char *
-get_altfilename(ifile)
-	IFILE ifile;
+get_altfilename(IFILE ifile)
 {
 	return (int_ifile(ifile)->h_altfilename);
 }

--- a/input.c
+++ b/input.c
@@ -40,12 +40,8 @@ extern int show_attn;
  * a line.  The new position is the position of the first character
  * of the NEXT line.  The line obtained is the line starting at curr_pos.
  */
-	public POSITION
-forw_line_seg(curr_pos, skipeol, rscroll, nochop)
-	POSITION curr_pos;
-	int skipeol;
-	int rscroll;
-	int nochop;
+	public POSITION 
+forw_line_seg(POSITION curr_pos, int skipeol, int rscroll, int nochop)
 {
 	POSITION base_pos;
 	POSITION new_pos;
@@ -258,9 +254,8 @@ get_forw_line:
 	return (new_pos);
 }
 
-	public POSITION
-forw_line(curr_pos)
-	POSITION curr_pos;
+	public POSITION 
+forw_line(POSITION curr_pos)
 {
 
 	return forw_line_seg(curr_pos, (chop_line() || hshift > 0), TRUE, FALSE);
@@ -273,9 +268,8 @@ forw_line(curr_pos)
  * a line.  The new position is the position of the first character
  * of the PREVIOUS line.  The line obtained is the one starting at new_pos.
  */
-	public POSITION
-back_line(curr_pos)
-	POSITION curr_pos;
+	public POSITION 
+back_line(POSITION curr_pos)
 {
 	POSITION new_pos, begin_new_pos, base_pos;
 	int c;
@@ -460,9 +454,8 @@ get_back_line:
 /*
  * Set attnpos.
  */
-	public void
-set_attnpos(pos)
-	POSITION pos;
+	public void 
+set_attnpos(POSITION pos)
 {
 	int c;
 

--- a/jump.c
+++ b/jump.c
@@ -86,9 +86,8 @@ jump_forw_buffered(VOID_PARAM)
 /*
  * Jump to line n in the file.
  */
-	public void
-jump_back(linenum)
-	LINENUM linenum;
+	public void 
+jump_back(LINENUM linenum)
 {
 	POSITION pos;
 	PARG parg;
@@ -139,10 +138,8 @@ repaint(VOID_PARAM)
 /*
  * Jump to a specified percentage into the file.
  */
-	public void
-jump_percent(percent, fraction)
-	int percent;
-	long fraction;
+	public void 
+jump_percent(int percent, long fraction)
 {
 	POSITION pos, len;
 
@@ -172,10 +169,8 @@ jump_percent(percent, fraction)
  * Like jump_loc, but the position need not be 
  * the first character in a line.
  */
-	public void
-jump_line_loc(pos, sline)
-	POSITION pos;
-	int sline;
+	public void 
+jump_line_loc(POSITION pos, int sline)
 {
 	int c;
 
@@ -200,10 +195,8 @@ jump_line_loc(pos, sline)
  * The position must be the first character in a line.
  * Place the target line on a specified line on the screen.
  */
-	public void
-jump_loc(pos, sline)
-	POSITION pos;
-	int sline;
+	public void 
+jump_loc(POSITION pos, int sline)
 {
 	int nline;
 	int sindex;

--- a/lessecho.c
+++ b/lessecho.c
@@ -61,19 +61,15 @@ pr_version(VOID_PARAM)
 	printf("%s\n", buf);
 }
 
-	static void
-pr_error(s)
-	char *s;
+	static void 
+pr_error(char *s)
 {
 	fprintf(stderr, "%s\n", s);
 	exit(1);
 }
 
-	static long
-lstrtol(s, pend, radix)
-	char *s;
-	char **pend;
-	int radix;
+	static long 
+lstrtol(char *s, char **pend, int radix)
 {
 	int v;
 	int neg = 0;
@@ -141,9 +137,8 @@ lstrtol(s, pend, radix)
 	return (n);
 }
 
-	static void
-add_metachar(ch)
-	int ch;
+	static void 
+add_metachar(int ch)
 {
 	if (num_metachars+1 >= size_metachars)
 	{
@@ -164,18 +159,15 @@ add_metachar(ch)
 	metachars[num_metachars] = '\0';
 }
 
-	static int
-is_metachar(ch)
-	int ch;
+	static int 
+is_metachar(int ch)
 {
 	return (metachars != NULL && strchr(metachars, ch) != NULL);
 }
 
 #if !HAVE_STRCHR
 	char *
-strchr(s, c)
-	char *s;
-	int c;
+strchr(char *s, int c)
 {
 	for ( ;  *s != '\0';  s++)
 		if (*s == c)
@@ -186,10 +178,8 @@ strchr(s, c)
 }
 #endif
 
-	int
-main(argc, argv)
-	int argc;
-	char *argv[];
+	int 
+main(int argc, char *argv[])
 {
 	char *arg;
 	char *s;

--- a/lesskey.c
+++ b/lesskey.c
@@ -115,26 +115,20 @@ usage(void)
 	exit(1);
 }
 
-	void
-lesskey_parse_error(s)
-	char *s;
+	void 
+lesskey_parse_error(char *s)
 {
 	fprintf(stderr, "%s\n", s);
 }
 
-	int
-lstrtoi(buf, ebuf, radix)
-	char *buf;
-	char **ebuf;
-	int radix;
+	int 
+lstrtoi(char *buf, char **ebuf, int radix)
 {
 	return (int) strtol(buf, ebuf, radix);
 }
 
 	void *
-ecalloc(count, size)
-	int count;
-	unsigned int size;
+ecalloc(int count, unsigned int size)
 {
 	void *p;
 
@@ -146,9 +140,7 @@ ecalloc(count, size)
 }
 
 	static char *
-mkpathname(dirname, filename)
-	char *dirname;
-	char *filename;
+mkpathname(char *dirname, char *filename)
 {
 	char *pathname;
 
@@ -163,8 +155,7 @@ mkpathname(dirname, filename)
  * Figure out the name of a default file (in the user's HOME directory).
  */
 	char *
-homefile(filename)
-	char *filename;
+homefile(char *filename)
 {
 	char *p;
 	char *pathname;
@@ -186,10 +177,8 @@ homefile(filename)
 /*
  * Parse command line arguments.
  */
-	static void
-parse_args(argc, argv)
-	int argc;
-	char **argv;
+	static void 
+parse_args(int argc, char **argv)
 {
 	char *arg;
 
@@ -259,11 +248,8 @@ parse_args(argc, argv)
 /*
  * Output some bytes.
  */
-	static void
-fputbytes(fd, buf, len)
-	FILE *fd;
-	char *buf;
-	int len;
+	static void 
+fputbytes(FILE *fd, char *buf, int len)
 {
 	while (len-- > 0)
 	{
@@ -275,10 +261,8 @@ fputbytes(fd, buf, len)
 /*
  * Output an integer, in special KRADIX form.
  */
-	static void
-fputint(fd, val)
-	FILE *fd;
-	unsigned int val;
+	static void 
+fputint(FILE *fd, unsigned int val)
 {
 	char c;
 
@@ -294,10 +278,8 @@ fputint(fd, val)
 	fwrite(&c, sizeof(char), 1, fd);
 }
 
-	int
-main(argc, argv)
-	int argc;
-	char *argv[];
+	int 
+main(int argc, char *argv[])
 {
 	struct lesskey_tables tables;
 	FILE *out;

--- a/lesskey_parse.c
+++ b/lesskey_parse.c
@@ -126,10 +126,8 @@ static struct lesskey_cmdname editnames[] =
 /*
  * Print a parse error message.
  */
-	static void
-parse_error(fmt, arg1)
-	char *fmt;
-	char *arg1;
+	static void 
+parse_error(char *fmt, char *arg1)
 {
 	char buf[1024];
 	int n = snprintf(buf, sizeof(buf), "%s: line %d: ", lesskey_file, linenum);
@@ -142,9 +140,8 @@ parse_error(fmt, arg1)
 /*
  * Initialize lesskey_tables.
  */
-	static void
-init_tables(tables)
-	struct lesskey_tables *tables;
+	static void 
+init_tables(struct lesskey_tables *tables)
 {
 	tables->currtable = &tables->cmdtable;
 
@@ -164,10 +161,7 @@ init_tables(tables)
 #define CHAR_STRING_LEN 8
 
 	static char *
-char_string(buf, ch, lit)
-	char *buf;
-	int ch;
-	int lit;
+char_string(char *buf, int ch, int lit)
 {
 	if (lit || (ch >= 0x20 && ch < 0x7f))
 	{
@@ -184,8 +178,7 @@ char_string(buf, ch, lit)
  * Increment char pointer by one up to terminating nul byte.
  */
 	static char *
-increment_pointer(p)
-	char *p;
+increment_pointer(char *p)
 {
 	if (*p == '\0')
 		return p;
@@ -196,9 +189,7 @@ increment_pointer(p)
  * Parse one character of a string.
  */
 	static char *
-tstr(pp, xlate)
-	char **pp;
-	int xlate;
+tstr(char **pp, int xlate)
 {
 	char *p;
 	char ch;
@@ -309,9 +300,8 @@ tstr(pp, xlate)
 	return (buf);
 }
 
-	static int
-issp(ch)
-	char ch;
+	static int 
+issp(int ch)
 {
 	return (ch == ' ' || ch == '\t');
 }
@@ -320,8 +310,7 @@ issp(ch)
  * Skip leading spaces in a string.
  */
 	static char *
-skipsp(s)
-	char *s;
+skipsp(char *s)
 {
 	while (issp(*s))
 		s++;
@@ -332,8 +321,7 @@ skipsp(s)
  * Skip non-space characters in a string.
  */
 	static char *
-skipnsp(s)
-	char *s;
+skipnsp(char *s)
 {
 	while (*s != '\0' && !issp(*s))
 		s++;
@@ -345,8 +333,7 @@ skipnsp(s)
  * strip off the trailing newline & any trailing # comment.
  */
 	static char *
-clean_line(s)
-	char *s;
+clean_line(char *s)
 {
 	int i;
 
@@ -361,17 +348,14 @@ clean_line(s)
 /*
  * Add a byte to the output command table.
  */
-	static void
-add_cmd_char(c, tables)
-	char c;
-	struct lesskey_tables *tables;
+	static void 
+add_cmd_char(int c, struct lesskey_tables *tables)
 {
 	xbuf_add_byte(&tables->currtable->buf, (unsigned char) c);
 }
 
-	static void
-erase_cmd_char(tables)
-	struct lesskey_tables *tables;
+	static void 
+erase_cmd_char(struct lesskey_tables *tables)
 {
 	xbuf_pop(&tables->currtable->buf);
 }
@@ -379,10 +363,8 @@ erase_cmd_char(tables)
 /*
  * Add a string to the output command table.
  */
-	static void
-add_cmd_str(s, tables)
-	char *s;
-	struct lesskey_tables *tables;
+	static void 
+add_cmd_str(char *s, struct lesskey_tables *tables)
 {
 	for ( ;  *s != '\0';  s++)
 		add_cmd_char(*s, tables);
@@ -392,10 +374,8 @@ add_cmd_str(s, tables)
  * Does a given version number match the running version?
  * Operator compares the running version to the given version.
  */
-	static int
-match_version(op, ver)
-	char op;
-	int ver;
+	static int 
+match_version(int op, int ver)
 {
 	switch (op)
 	{
@@ -415,9 +395,7 @@ match_version(op, ver)
  * Otherwise, return NULL.
  */
 	static char *
-version_line(s, tables)
-	char *s;
-	struct lesskey_tables *tables;
+version_line(char *s, struct lesskey_tables *tables)
 {
 	char op;
 	int ver;
@@ -454,9 +432,7 @@ version_line(s, tables)
  * See if we have a special "control" line.
  */
 	static char *
-control_line(s, tables)
-	char *s;
-	struct lesskey_tables *tables;
+control_line(char *s, struct lesskey_tables *tables)
 {
 #define PREFIX(str,pat) (strncmp(str,pat,strlen(pat)) == 0)
 
@@ -491,10 +467,8 @@ control_line(s, tables)
 /*
  * Find an action, given the name of the action.
  */
-	static int
-findaction(actname, tables)
-	char *actname;
-	struct lesskey_tables *tables;
+	static int 
+findaction(char *actname, struct lesskey_tables *tables)
 {
 	int i;
 
@@ -512,10 +486,8 @@ findaction(actname, tables)
  * resulting less action, and EXTRA is an "extra" user
  * key sequence injected after the action.
  */
-	static void
-parse_cmdline(p, tables)
-	char *p;
-	struct lesskey_tables *tables;
+	static void 
+parse_cmdline(char *p, struct lesskey_tables *tables)
 {
 	char *actname;
 	int action;
@@ -581,10 +553,8 @@ parse_cmdline(p, tables)
  * Parse a variable definition line, of the form
  *  NAME = VALUE
  */
-	static void
-parse_varline(line, tables)
-	char *line;
-	struct lesskey_tables *tables;
+	static void 
+parse_varline(char *line, struct lesskey_tables *tables)
 {
 	char *s;
 	char *p = line;
@@ -631,10 +601,8 @@ parse_varline(line, tables)
 /*
  * Parse a line from the lesskey file.
  */
-	static void
-parse_line(line, tables)
-	char *line;
-	struct lesskey_tables *tables;
+	static void 
+parse_line(char *line, struct lesskey_tables *tables)
 {
 	char *p;
 
@@ -662,10 +630,8 @@ parse_line(line, tables)
 /*
  * Parse a lesskey source file and store result in tables.
  */
-	int
-parse_lesskey(infile, tables)
-	char *infile;
-	struct lesskey_tables *tables;
+	int 
+parse_lesskey(char *infile, struct lesskey_tables *tables)
 {
 	FILE *desc;
 	char line[1024];

--- a/line.c
+++ b/line.c
@@ -191,18 +191,16 @@ expand_linebuf(VOID_PARAM)
 /*
  * Is a character ASCII?
  */
-	public int
-is_ascii_char(ch)
-	LWCHAR ch;
+	public int 
+is_ascii_char(LWCHAR ch)
 {
 	return (ch <= 0x7F);
 }
 
 /*
  */
-	static void
-inc_end_column(w)
-	int w;
+	static void 
+inc_end_column(int w)
 {
 	if (end_column > right_column && w > 0)
 	{
@@ -251,11 +249,8 @@ prewind(VOID_PARAM)
 /*
  * Set a character in the line buffer.
  */
-	static void
-set_linebuf(n, ch, attr)
-	int n;
-	char ch;
-	int attr;
+	static void 
+set_linebuf(int n, int ch, int attr)
 {
 	linebuf.buf[n] = ch;
 	linebuf.attr[n] = attr;
@@ -264,11 +259,8 @@ set_linebuf(n, ch, attr)
 /*
  * Append a character to the line buffer.
  */
-	static void
-add_linebuf(ch, attr, w)
-	char ch;
-	int attr;
-	int w;
+	static void 
+add_linebuf(int ch, int attr, int w)
 {
 	set_linebuf(linebuf.end++, ch, attr);
 	inc_end_column(w);
@@ -277,11 +269,8 @@ add_linebuf(ch, attr, w)
 /*
  * Append a string to the line buffer.
  */
-	static void
-addstr_linebuf(s, attr, cw)
-	char *s;
-	int attr;
-	int cw;
+	static void 
+addstr_linebuf(char *s, int attr, int cw)
 {
 	for ( ;  *s != '\0';  s++)
 		add_linebuf(*s, attr, cw);
@@ -290,11 +279,8 @@ addstr_linebuf(s, attr, cw)
 /*
  * Set a character in the line prefix buffer.
  */
-	static void
-set_pfx(n, ch, attr)
-	int n;
-	char ch;
-	int attr;
+	static void 
+set_pfx(int n, int ch, int attr)
 {
 	linebuf.pfx[n] = ch;
 	linebuf.pfx_attr[n] = attr;
@@ -303,10 +289,8 @@ set_pfx(n, ch, attr)
 /*
  * Append a character to the line prefix buffer.
  */
-	static void
-add_pfx(ch, attr)
-	char ch;
-	int attr;
+	static void 
+add_pfx(int ch, int attr)
 {
 	set_pfx(linebuf.pfx_end++, ch, attr);
 }
@@ -314,9 +298,8 @@ add_pfx(ch, attr)
 /*
  * Insert the status column and line number into the line buffer.
  */
-	public void
-plinestart(pos)
-	POSITION pos;
+	public void 
+plinestart(POSITION pos)
 {
 	LINENUM linenum = 0;
 	int i;
@@ -413,9 +396,8 @@ pshift_all(VOID_PARAM)
  * Return the printing width of the start (enter) sequence
  * for a given character attribute.
  */
-	static int
-attr_swidth(a)
-	int a;
+	static int 
+attr_swidth(int a)
 {
 	int w = 0;
 
@@ -437,9 +419,8 @@ attr_swidth(a)
  * Return the printing width of the end (exit) sequence
  * for a given character attribute.
  */
-	static int
-attr_ewidth(a)
-	int a;
+	static int 
+attr_ewidth(int a)
 {
 	int w = 0;
 
@@ -463,12 +444,8 @@ attr_ewidth(a)
  * Adding a character with a given attribute may cause an enter or exit
  * attribute sequence to be inserted, so this must be taken into account.
  */
-	public int
-pwidth(ch, a, prev_ch, prev_a)
-	LWCHAR ch;
-	int a;
-	LWCHAR prev_ch;
-	int prev_a;
+	public int 
+pwidth(LWCHAR ch, int a, LWCHAR prev_ch, int prev_a)
 {
 	int w;
 
@@ -560,9 +537,8 @@ backc(VOID_PARAM)
 /*
  * Is a character the end of an ANSI escape sequence?
  */
-	public int
-is_ansi_end(ch)
-	LWCHAR ch;
+	public int 
+is_ansi_end(LWCHAR ch)
 {
 	if (!is_ascii_char(ch))
 		return (0);
@@ -572,9 +548,8 @@ is_ansi_end(ch)
 /*
  * Can a char appear in an ANSI escape sequence, before the end char?
  */
-	public int
-is_ansi_middle(ch)
-	LWCHAR ch;
+	public int 
+is_ansi_middle(LWCHAR ch)
 {
 	if (!is_ascii_char(ch))
 		return (0);
@@ -587,11 +562,8 @@ is_ansi_middle(ch)
  * Skip past an ANSI escape sequence.
  * pp is initially positioned just after the CSI_START char.
  */
-	public void
-skip_ansi(pansi, pp, limit)
-	struct ansi_state *pansi;
-	char **pp;
-	constant char *limit;
+	public void 
+skip_ansi(struct ansi_state *pansi, char **pp, constant char *limit)
 {
 	LWCHAR c;
 	do {
@@ -605,8 +577,7 @@ skip_ansi(pansi, pp, limit)
  * If so, return an ansi_state struct; otherwise return NULL.
  */
 	public struct ansi_state *
-ansi_start(ch)
-	LWCHAR ch;
+ansi_start(LWCHAR ch)
 {
 	struct ansi_state *pansi;
 
@@ -623,10 +594,8 @@ ansi_start(ch)
  * Determine whether the next char in an ANSI escape sequence
  * ends the sequence.
  */
-	public int
-ansi_step(pansi, ch)
-	struct ansi_state *pansi;
-	LWCHAR ch;
+	public int 
+ansi_step(struct ansi_state *pansi, LWCHAR ch)
 {
 	if (pansi->hlink)
 	{
@@ -662,9 +631,8 @@ ansi_step(pansi, ch)
 /*
  * Free an ansi_state structure.
  */
-	public void
-ansi_done(pansi)
-	struct ansi_state *pansi;
+	public void 
+ansi_done(struct ansi_state *pansi)
 {
 	free(pansi);
 }
@@ -672,10 +640,8 @@ ansi_done(pansi)
 /*
  * Will w characters in attribute a fit on the screen?
  */
-	static int
-fits_on_screen(w, a)
-	int w;
-	int a;
+	static int 
+fits_on_screen(int w, int a)
 {
 	if (ctldisp == OPT_ON)
 		/* We're not counting, so say that everything fits. */
@@ -691,12 +657,8 @@ fits_on_screen(w, a)
 		if (store_char((ch),(a),(rep),(pos))) return (1); \
 	} while (0)
 
-	static int
-store_char(ch, a, rep, pos)
-	LWCHAR ch;
-	int a;
-	char *rep;
-	POSITION pos;
+	static int 
+store_char(LWCHAR ch, int a, char *rep, POSITION pos)
 {
 	int w;
 	int i;
@@ -838,11 +800,8 @@ store_char(ch, a, rep, pos)
 #define STORE_STRING(s,a,pos) \
 	do { if (store_string((s),(a),(pos))) return (1); } while (0)
 
-	static int
-store_string(s, a, pos)
-	char *s;
-	int a;
-	POSITION pos;
+	static int 
+store_string(char *s, int a, POSITION pos)
 {
 	if (!fits_on_screen(strlen(s), a))
 		return 1;
@@ -858,10 +817,8 @@ store_string(s, a, pos)
 #define STORE_TAB(a,pos) \
 	do { if (store_tab((a),(pos))) return (1); } while (0)
 
-	static int
-store_tab(attr, pos)
-	int attr;
-	POSITION pos;
+	static int 
+store_tab(int attr, POSITION pos)
 {
 	int to_tab = end_column - linebuf.pfx_end;
 
@@ -886,10 +843,8 @@ store_tab(attr, pos)
 #define STORE_PRCHAR(c, pos) \
 	do { if (store_prchar((c), (pos))) return 1; } while (0)
 
-	static int
-store_prchar(c, pos)
-	LWCHAR c;
-	POSITION pos;
+	static int 
+store_prchar(LWCHAR c, POSITION pos)
 {
 	/*
 	 * Convert to printable representation.
@@ -898,9 +853,8 @@ store_prchar(c, pos)
 	return 0;
 }
 
-	static int
-flush_mbc_buf(pos)
-	POSITION pos;
+	static int 
+flush_mbc_buf(POSITION pos)
 {
 	int i;
 
@@ -915,10 +869,8 @@ flush_mbc_buf(pos)
  * Expand tabs into spaces, handle underlining, boldfacing, etc.
  * Returns 0 if ok, 1 if couldn't fit in buffer.
  */
-	public int
-pappend(c, pos)
-	int c;
-	POSITION pos;
+	public int 
+pappend(int c, POSITION pos)
 {
 	int r;
 
@@ -1008,11 +960,8 @@ pappend(c, pos)
 	return (r);
 }
 
-	static int
-store_control_char(ch, rep, pos)
-	LWCHAR ch;
-	char *rep;
-	POSITION pos;
+	static int 
+store_control_char(LWCHAR ch, char *rep, POSITION pos)
 {
 	if (ctldisp == OPT_ON)
 	{
@@ -1026,11 +975,8 @@ store_control_char(ch, rep, pos)
 	return (0);
 }
 
-	static int
-store_ansi(ch, rep, pos)
-	LWCHAR ch;
-	char *rep;
-	POSITION pos;
+	static int 
+store_ansi(LWCHAR ch, char *rep, POSITION pos)
 {
 	switch (ansi_step(line_ansi, ch))
 	{
@@ -1069,11 +1015,8 @@ store_ansi(ch, rep, pos)
 	return (0);
 } 
 
-	static int
-store_bs(ch, rep, pos)
-	LWCHAR ch;
-	char *rep;
-	POSITION pos;
+	static int 
+store_bs(LWCHAR ch, char *rep, POSITION pos)
 {
 	if (bs_mode == BS_CONTROL)
 		return store_control_char(ch, rep, pos);
@@ -1088,11 +1031,8 @@ store_bs(ch, rep, pos)
 	return 0;
 }
 
-	static int
-do_append(ch, rep, pos)
-	LWCHAR ch;
-	char *rep;
-	POSITION pos;
+	static int 
+do_append(LWCHAR ch, char *rep, POSITION pos)
 {
 	int a = AT_NORMAL;
 	int in_overstrike = overstrike;
@@ -1232,11 +1172,8 @@ add_attr_normal(VOID_PARAM)
 /*
  * Terminate the line in the line buffer.
  */
-	public void
-pdone(endline, chopped, forw)
-	int endline;
-	int chopped;
-	int forw;
+	public void 
+pdone(int endline, int chopped, int forw)
 {
 	(void) pflushmbc();
 
@@ -1328,9 +1265,8 @@ pdone(endline, chopped, forw)
 /*
  * Set an attribute on each char of the line in the line buffer.
  */
-	public void
-set_attr_line(a)
-	int a;
+	public void 
+set_attr_line(int a)
 {
 	int i;
 
@@ -1341,10 +1277,8 @@ set_attr_line(a)
 /*
  * Set the char to be displayed in the status column.
  */
-	public void
-set_status_col(c, attr)
-	int c;
-	int attr;
+	public void 
+set_status_col(int c, int attr)
 {
 	set_pfx(0, c, attr);
 }
@@ -1354,10 +1288,8 @@ set_status_col(c, attr)
  * Return the character as the function return value,
  * and the character attribute in *ap.
  */
-	public int
-gline(i, ap)
-	int i;
-	int *ap;
+	public int 
+gline(int i, int *ap)
 {
 	if (is_null_line)
 	{
@@ -1404,11 +1336,8 @@ null_line(VOID_PARAM)
  * lines which are not split for screen width.
  * {{ This is supposed to be more efficient than forw_line(). }}
  */
-	public POSITION
-forw_raw_line(curr_pos, linep, line_lenp)
-	POSITION curr_pos;
-	char **linep;
-	int *line_lenp;
+	public POSITION 
+forw_raw_line(POSITION curr_pos, char **linep, int *line_lenp)
 {
 	int n;
 	int c;
@@ -1453,11 +1382,8 @@ forw_raw_line(curr_pos, linep, line_lenp)
  * Analogous to back_line(), but deals with "raw lines".
  * {{ This is supposed to be more efficient than back_line(). }}
  */
-	public POSITION
-back_raw_line(curr_pos, linep, line_lenp)
-	POSITION curr_pos;
-	char **linep;
-	int *line_lenp;
+	public POSITION 
+back_raw_line(POSITION curr_pos, char **linep, int *line_lenp)
 {
 	int n;
 	int c;
@@ -1526,9 +1452,8 @@ back_raw_line(curr_pos, linep, line_lenp)
 /*
  * Append a string to the line buffer.
  */
-	static int
-pappstr(str)
-	constant char *str;
+	static int 
+pappstr(constant char *str)
 {
 	while (*str != '\0')
 	{
@@ -1544,9 +1469,8 @@ pappstr(str)
  * If the string is too long to fit on the screen,
  * truncate the beginning of the string to fit.
  */
-	public void
-load_line(str)
-	constant char *str;
+	public void 
+load_line(constant char *str)
 {
 	int save_hshift = hshift;
 
@@ -1596,9 +1520,8 @@ rrshift(VOID_PARAM)
 /*
  * Get the color_map index associated with a given attribute.
  */
-	static int
-color_index(attr)
-	int attr;
+	static int 
+color_index(int attr)
 {
 	if (use_color)
 	{
@@ -1630,10 +1553,8 @@ color_index(attr)
 /*
  * Set the color string to use for a given attribute.
  */
-	public int
-set_color_map(attr, colorstr)
-	int attr;
-	char *colorstr;
+	public int 
+set_color_map(int attr, char *colorstr)
 {
 	int cx = color_index(attr);
 	if (cx < 0)
@@ -1650,8 +1571,7 @@ set_color_map(attr, colorstr)
  * Get the color string to use for a given attribute.
  */
 	public char *
-get_color_map(attr)
-	int attr;
+get_color_map(int attr)
 {
 	int cx = color_index(attr);
 	if (cx < 0)

--- a/linenum.c
+++ b/linenum.c
@@ -102,9 +102,8 @@ clr_linenum(VOID_PARAM)
 /*
  * Calculate the gap for an entry.
  */
-	static void
-calcgap(p)
-	struct linenum_info *p;
+	static void 
+calcgap(struct linenum_info *p)
 {
 	/*
 	 * Don't bother to compute a gap for the anchor.
@@ -122,10 +121,8 @@ calcgap(p)
  * The specified position (pos) should be the file position of the
  * FIRST character in the specified line.
  */
-	public void
-add_lnum(linenum, pos)
-	LINENUM linenum;
-	POSITION pos;
+	public void 
+add_lnum(LINENUM linenum, POSITION pos)
 {
 	struct linenum_info *p;
 	struct linenum_info *new;
@@ -265,9 +262,8 @@ abort_long(VOID_PARAM)
  * Find the line number associated with a given position.
  * Return 0 if we can't figure it out.
  */
-	public LINENUM
-find_linenum(pos)
-	POSITION pos;
+	public LINENUM 
+find_linenum(POSITION pos)
 {
 	struct linenum_info *p;
 	LINENUM linenum;
@@ -379,9 +375,8 @@ find_linenum(pos)
  * Find the position of a given line number.
  * Return NULL_POSITION if we can't figure it out.
  */
-	public POSITION
-find_pos(linenum)
-	LINENUM linenum;
+	public POSITION 
+find_pos(LINENUM linenum)
 {
 	struct linenum_info *p;
 	POSITION cpos;
@@ -452,9 +447,8 @@ find_pos(linenum)
  * The argument "where" tells which line is to be considered
  * the "current" line (e.g. TOP, BOTTOM, MIDDLE, etc).
  */
-	public LINENUM
-currline(where)
-	int where;
+	public LINENUM 
+currline(int where)
 {
 	POSITION pos;
 	POSITION len;
@@ -499,9 +493,8 @@ scan_eof(VOID_PARAM)
  * Return a line number adjusted for display
  * (handles the --no-number-headers option).
  */
-	public LINENUM
-vlinenum(linenum)
-	LINENUM linenum;
+	public LINENUM 
+vlinenum(LINENUM linenum)
 {
 	if (nonum_headers)
 		linenum = (linenum < header_lines) ? 0 : linenum - header_lines;

--- a/lsystem.c
+++ b/lsystem.c
@@ -42,10 +42,8 @@ extern IFILE curr_ifile;
  * Pass the specified command to a shell to be executed.
  * Like plain "system()", but handles resetting terminal modes, etc.
  */
-	public void
-lsystem(cmd, donemsg)
-	char *cmd;
-	char *donemsg;
+	public void 
+lsystem(char *cmd, char *donemsg)
 {
 	int inp;
 #if HAVE_SHELL
@@ -251,10 +249,8 @@ lsystem(cmd, donemsg)
  * If the mark is on the current screen, or if the mark is ".",
  * the whole current screen is piped.
  */
-	public int
-pipe_mark(c, cmd)
-	int c;
-	char *cmd;
+	public int 
+pipe_mark(int c, char *cmd)
 {
 	POSITION mpos, tpos, bpos;
 
@@ -285,11 +281,8 @@ pipe_mark(c, cmd)
  * Create a pipe to the given shell command.
  * Feed it the file contents between the positions spos and epos.
  */
-	public int
-pipe_data(cmd, spos, epos)
-	char *cmd;
-	POSITION spos;
-	POSITION epos;
+	public int 
+pipe_data(char *cmd, POSITION spos, POSITION epos)
 {
 	FILE *f;
 	int c;

--- a/main.c
+++ b/main.c
@@ -68,10 +68,8 @@ extern int      first_time;
 /*
  * Entry point.
  */
-int
-main(argc, argv)
-	int argc;
-	char *argv[];
+int 
+main(int argc, char *argv[])
 {
 	IFILE ifile;
 	char *s;
@@ -314,8 +312,7 @@ main(argc, argv)
  * (that is, to a buffer allocated by calloc).
  */
 	public char *
-save(s)
-	constant char *s;
+save(constant char *s)
 {
 	char *p;
 
@@ -328,10 +325,8 @@ save(s)
  * Allocate memory.
  * Like calloc(), but never returns an error (NULL).
  */
-	public VOID_POINTER
-ecalloc(count, size)
-	int count;
-	unsigned int size;
+	public VOID_POINTER 
+ecalloc(int count, unsigned int size)
 {
 	VOID_POINTER p;
 
@@ -348,8 +343,7 @@ ecalloc(count, size)
  * Skip leading spaces in a string.
  */
 	public char *
-skipsp(s)
-	char *s;
+skipsp(char *s)
 {
 	while (*s == ' ' || *s == '\t')
 		s++;
@@ -361,11 +355,8 @@ skipsp(s)
  * If uppercase is true, the first string must begin with an uppercase
  * character; the remainder of the first string may be either case.
  */
-	public int
-sprefix(ps, s, uppercase)
-	char *ps;
-	char *s;
-	int uppercase;
+	public int 
+sprefix(char *ps, char *s, int uppercase)
 {
 	int c;
 	int sc;
@@ -394,9 +385,8 @@ sprefix(ps, s, uppercase)
 /*
  * Exit the program.
  */
-	public void
-quit(status)
-	int status;
+	public void 
+quit(int status)
 {
 	static int save_status;
 

--- a/mark.c
+++ b/mark.c
@@ -49,12 +49,8 @@ public int marks_modified = 0;
 /*
  * Initialize a mark struct.
  */
-	static void
-cmark(m, ifile, pos, ln)
-	struct mark *m;
-	IFILE ifile;
-	POSITION pos;
-	int ln;
+	static void 
+cmark(struct mark *m, IFILE ifile, POSITION pos, int ln)
 {
 	m->m_ifile = ifile;
 	m->m_scrpos.pos = pos;
@@ -89,10 +85,8 @@ init_mark(VOID_PARAM)
 /*
  * Set m_ifile and clear m_filename.
  */
-	static void
-mark_set_ifile(m, ifile)
-	struct mark *m;
-	IFILE ifile;
+	static void 
+mark_set_ifile(struct mark *m, IFILE ifile)
 {
 	m->m_ifile = ifile;
 	/* With m_ifile set, m_filename is no longer needed. */
@@ -103,9 +97,8 @@ mark_set_ifile(m, ifile)
 /*
  * Populate the m_ifile member of a mark struct from m_filename.
  */
-	static void
-mark_get_ifile(m)
-	struct mark *m;
+	static void 
+mark_get_ifile(struct mark *m)
 {
 	if (m->m_ifile != NULL_IFILE)
 		return; /* m_ifile is already set */
@@ -116,8 +109,7 @@ mark_get_ifile(m)
  * Return the user mark struct identified by a character.
  */
 	static struct mark *
-getumark(c)
-	int c;
+getumark(int c)
 {
 	PARG parg;
 	if (c >= 'a' && c <= 'z')
@@ -139,8 +131,7 @@ getumark(c)
  * or may be constructed on the fly for certain characters like ^, $.
  */
 	static struct mark *
-getmark(c)
-	int c;
+getmark(int c)
 {
 	struct mark *m;
 	static struct mark sm;
@@ -200,9 +191,8 @@ getmark(c)
 /*
  * Is a mark letter invalid?
  */
-	public int
-badmark(c)
-	int c;
+	public int 
+badmark(int c)
 {
 	return (getmark(c) == NULL);
 }
@@ -210,10 +200,8 @@ badmark(c)
 /*
  * Set a user-defined mark.
  */
-	public void
-setmark(c, where)
-	int c;
-	int where;
+	public void 
+setmark(int c, int where)
 {
 	struct mark *m;
 	struct scrpos scrpos;
@@ -234,9 +222,8 @@ setmark(c, where)
 /*
  * Clear a user-defined mark.
  */
-	public void
-clrmark(c)
-	int c;
+	public void 
+clrmark(int c)
 {
 	struct mark *m;
 
@@ -272,9 +259,8 @@ lastmark(VOID_PARAM)
 /*
  * Go to a mark.
  */
-	public void
-gomark(c)
-	int c;
+	public void 
+gomark(int c)
 {
 	struct mark *m;
 	struct scrpos scrpos;
@@ -315,9 +301,8 @@ gomark(c)
  * is associated with, but this doesn't matter much,
  * because it's always the first non-blank line on the screen.
  */
-	public POSITION
-markpos(c)
-	int c;
+	public POSITION 
+markpos(int c)
 {
 	struct mark *m;
 
@@ -336,9 +321,8 @@ markpos(c)
 /*
  * Return the mark associated with a given position, if any.
  */
-	public char
-posmark(pos)
-	POSITION pos;
+	public char 
+posmark(POSITION pos)
 {
 	int i;
 
@@ -358,9 +342,8 @@ posmark(pos)
 /*
  * Clear the marks associated with a specified ifile.
  */
-	public void
-unmark(ifile)
-	IFILE ifile;
+	public void 
+unmark(IFILE ifile)
 {
 	int i;
 
@@ -373,9 +356,8 @@ unmark(ifile)
  * Check if any marks refer to a specified ifile vi m_filename
  * rather than m_ifile.
  */
-	public void
-mark_check_ifile(ifile)
-	IFILE ifile;
+	public void 
+mark_check_ifile(IFILE ifile)
 {
 	int i;
 	char *filename = get_real_filename(ifile);
@@ -399,10 +381,8 @@ mark_check_ifile(ifile)
 /*
  * Save marks to history file.
  */
-	public void
-save_marks(fout, hdr)
-	FILE *fout;
-	char *hdr;
+	public void 
+save_marks(FILE *fout, char *hdr)
 {
 	int i;
 
@@ -430,9 +410,8 @@ save_marks(fout, hdr)
 /*
  * Restore one mark from the history file.
  */
-	public void
-restore_mark(line)
-	char *line;
+	public void 
+restore_mark(char *line)
 {
 	struct mark *m;
 	int ln;

--- a/mkfuncs.pl
+++ b/mkfuncs.pl
@@ -10,18 +10,11 @@ while (<>) {
 		$def = "public $1";
 		$state = 1;
 		$params = 0;
-	} elsif ($state == 1 and /(\w+)\s*\(/) {
-		$def .= " $1 LESSPARAMS ((";
+	} elsif ($state == 1 and /(\w+)\s*\((.*)\)/) {
+		$def .= " $1 LESSPARAMS (($2))";
 		$state = 2;
 	} elsif ($state == 2) {
-		if (/^{/) {
-			$def .= 'VOID_PARAM' if not $params;
-			print "$def));\n";
-			$state = 0;
-		} elsif (/^\s*([^;]*)/) {
-			$def .= ', ' if substr($def,-1) ne '(';
-			$def .= $1;
-			$params = 1;
-		}
+		print "$def;\n";
+		$state = 0;
 	}
 }

--- a/mkfuncs.py
+++ b/mkfuncs.py
@@ -12,15 +12,9 @@ for line in fileinput.input():
             definition = 'public ' + test.group(1)
             state = 1
             params = 0
-        elif (state == 1) and (test := re.search(r'(\w+)\s*\(', line)):
-            definition = '{0} LESSPARAMS (('.format(test.group(1))
+        elif (state == 1) and (test := re.search(r'(\w+)\s*\((.*)\)', line)):
+            definition += '{0} LESSPARAMS (({1}))'.format(test.group(1), test.group(2))
             state = 2
         elif state == 2:
-            if re.search(r'^{', line):
-                if not params: definition += 'VOID_PARAM'
-                print(f'{definition}));')
-                state = 0
-            elif test := re.search(r'^\s*([^;]*)', line):
-                if (definition[-1:] != '('): definition += ', ' 
-                definition += test.group(1) 
-                params = 1
+            print(f'{definition};')
+            state = 0

--- a/optfunc.c
+++ b/optfunc.c
@@ -95,10 +95,8 @@ extern int sgr_mode;
 /*
  * Handler for -o option.
  */
-	public void
-opt_o(type, s)
-	int type;
-	char *s;
+	public void 
+opt_o(int type, char *s)
 {
 	PARG parg;
 	char *filename;
@@ -148,10 +146,8 @@ opt_o(type, s)
 /*
  * Handler for -O option.
  */
-	public void
-opt__O(type, s)
-	int type;
-	char *s;
+	public void 
+opt__O(int type, char *s)
 {
 	force_logfile = TRUE;
 	opt_o(type, s);
@@ -161,10 +157,8 @@ opt__O(type, s)
 /*
  * Handlers for -j option.
  */
-	public void
-opt_j(type, s)
-	int type;
-	char *s;
+	public void 
+opt_j(int type, char *s)
 {
 	PARG parg;
 	int len;
@@ -225,10 +219,8 @@ calc_jump_sline(VOID_PARAM)
 /*
  * Handlers for -# option.
  */
-	public void
-opt_shift(type, s)
-	int type;
-	char *s;
+	public void 
+opt_shift(int type, char *s)
 {
 	PARG parg;
 	int len;
@@ -287,10 +279,8 @@ calc_shift_count(VOID_PARAM)
 }
 
 #if USERFILE
-	public void
-opt_k(type, s)
-	int type;
-	char *s;
+	public void 
+opt_k(int type, char *s)
 {
 	PARG parg;
 
@@ -307,10 +297,8 @@ opt_k(type, s)
 }
 
 #if HAVE_LESSKEYSRC 
-	public void
-opt_ks(type, s)
-	int type;
-	char *s;
+	public void 
+opt_ks(int type, char *s)
 {
 	PARG parg;
 
@@ -332,10 +320,8 @@ opt_ks(type, s)
 /*
  * Handler for -t option.
  */
-	public void
-opt_t(type, s)
-	int type;
-	char *s;
+	public void 
+opt_t(int type, char *s)
 {
 	IFILE save_ifile;
 	POSITION pos;
@@ -373,10 +359,8 @@ opt_t(type, s)
 /*
  * Handler for -T option.
  */
-	public void
-opt__T(type, s)
-	int type;
-	char *s;
+	public void 
+opt__T(int type, char *s)
 {
 	PARG parg;
 	char *filename;
@@ -405,10 +389,8 @@ opt__T(type, s)
 /*
  * Handler for -p option.
  */
-	public void
-opt_p(type, s)
-	int type;
-	char *s;
+	public void 
+opt_p(int type, char *s)
 {
 	switch (type)
 	{
@@ -441,10 +423,8 @@ opt_p(type, s)
 /*
  * Handler for -P option.
  */
-	public void
-opt__P(type, s)
-	int type;
-	char *s;
+	public void 
+opt__P(int type, char *s)
 {
 	char **proto;
 	PARG parg;
@@ -480,10 +460,8 @@ opt__P(type, s)
  * Handler for the -b option.
  */
 	/*ARGSUSED*/
-	public void
-opt_b(type, s)
-	int type;
-	char *s;
+	public void 
+opt_b(int type, char *s)
 {
 	switch (type)
 	{
@@ -503,10 +481,8 @@ opt_b(type, s)
  * Handler for the -i option.
  */
 	/*ARGSUSED*/
-	public void
-opt_i(type, s)
-	int type;
-	char *s;
+	public void 
+opt_i(int type, char *s)
 {
 	switch (type)
 	{
@@ -523,10 +499,8 @@ opt_i(type, s)
  * Handler for the -V option.
  */
 	/*ARGSUSED*/
-	public void
-opt__V(type, s)
-	int type;
-	char *s;
+	public void 
+opt__V(int type, char *s)
 {
 	switch (type)
 	{
@@ -568,11 +542,8 @@ opt__V(type, s)
 /*
  * Parse an MSDOS color descriptor.
  */
-	static void
-colordesc(s, fg_color, bg_color)
-	char *s;
-	int *fg_color;
-	int *bg_color;
+	static void 
+colordesc(char *s, int *fg_color, int *bg_color)
 {
 	int fg, bg;
 #if MSDOS_COMPILER==WIN32C
@@ -610,9 +581,8 @@ colordesc(s, fg_color, bg_color)
 }
 #endif
 
-	static int
-color_from_namechar(namechar)
-	char namechar;
+	static int 
+color_from_namechar(int namechar)
 {
 	switch (namechar)
 	{
@@ -639,10 +609,8 @@ color_from_namechar(namechar)
  * Handler for the -D option.
  */
 	/*ARGSUSED*/
-	public void
-opt_D(type, s)
-	int type;
-	char *s;
+	public void 
+opt_D(int type, char *s)
 {
 	PARG p;
 	int attr;
@@ -718,10 +686,8 @@ opt_D(type, s)
 /*
  * Handler for the -x option.
  */
-	public void
-opt_x(type, s)
-	int type;
-	char *s;
+	public void 
+opt_x(int type, char *s)
 {
 	extern int tabstops[];
 	extern int ntabstops;
@@ -776,10 +742,8 @@ opt_x(type, s)
 /*
  * Handler for the -" option.
  */
-	public void
-opt_quote(type, s)
-	int type;
-	char *s;
+	public void 
+opt_quote(int type, char *s)
 {
 	char buf[3];
 	PARG parg;
@@ -818,10 +782,8 @@ opt_quote(type, s)
  * Handler for the --rscroll option.
  */
 	/*ARGSUSED*/
-	public void
-opt_rscroll(type, s)
-	int type;
-	char *s;
+	public void 
+opt_rscroll(int type, char *s)
 {
 	PARG p;
 
@@ -853,10 +815,8 @@ opt_rscroll(type, s)
  * If from the command line, exit immediately.
  */
 	/*ARGSUSED*/
-	public void
-opt_query(type, s)
-	int type;
-	char *s;
+	public void 
+opt_query(int type, char *s)
 {
 	switch (type)
 	{
@@ -873,10 +833,8 @@ opt_query(type, s)
  * Handler for the --mouse option.
  */
 	/*ARGSUSED*/
-	public void
-opt_mousecap(type, s)
-	int type;
-	char *s;
+	public void 
+opt_mousecap(int type, char *s)
 {
 	switch (type)
 	{
@@ -896,10 +854,8 @@ opt_mousecap(type, s)
  * Handler for the --wheel-lines option.
  */
 	/*ARGSUSED*/
-	public void
-opt_wheel_lines(type, s)
-	int type;
-	char *s;
+	public void 
+opt_wheel_lines(int type, char *s)
 {
 	switch (type)
 	{
@@ -917,10 +873,8 @@ opt_wheel_lines(type, s)
  * Handler for the --line-number-width option.
  */
 	/*ARGSUSED*/
-	public void
-opt_linenum_width(type, s)
-	int type;
-	char *s;
+	public void 
+opt_linenum_width(int type, char *s)
 {
 	PARG parg;
 
@@ -944,10 +898,8 @@ opt_linenum_width(type, s)
  * Handler for the --status-column-width option.
  */
 	/*ARGSUSED*/
-	public void
-opt_status_col_width(type, s)
-	int type;
-	char *s;
+	public void 
+opt_status_col_width(int type, char *s)
 {
 	PARG parg;
 
@@ -971,10 +923,8 @@ opt_status_col_width(type, s)
  * Handler for the --file-size option.
  */
 	/*ARGSUSED*/
-	public void
-opt_filesize(type, s)
-	int type;
-	char *s;
+	public void 
+opt_filesize(int type, char *s)
 {
 	switch (type)
 	{
@@ -992,10 +942,8 @@ opt_filesize(type, s)
  * Handler for the --header option.
  */
 	/*ARGSUSED*/
-	public void
-opt_header(type, s)
-	int type;
-	char *s;
+	public void 
+opt_header(int type, char *s)
 {
 	int err;
 	int n;
@@ -1038,10 +986,8 @@ opt_header(type, s)
  * Handler for the --search-options option.
  */
 	/*ARGSUSED*/
-	public void
-opt_search_type(type, s)
-	int type;
-	char *s;
+	public void 
+opt_search_type(int type, char *s)
 {
 	int st;
 	PARG parg;
@@ -1095,10 +1041,8 @@ opt_search_type(type, s)
  * Handler for the --tty option.
  */
 	/*ARGSUSED*/
-	public void
-opt_ttyin_name(type, s)
-	int type;
-	char *s;
+	public void 
+opt_ttyin_name(int type, char *s)
 {
 	switch (type)
 	{

--- a/option.c
+++ b/option.c
@@ -36,8 +36,7 @@ extern int opt_use_backslash;
  * Return a printable description of an option.
  */
 	static char *
-opt_desc(o)
-	struct loption *o;
+opt_desc(struct loption *o)
 {
 	static char buf[OPTNAME_MAX + 10];
 	if (o->oletter == OLETTER_NONE)
@@ -52,8 +51,7 @@ opt_desc(o)
  * For example, if the option letter is 'x', just return "-x".
  */
 	public char *
-propt(c)
-	int c;
+propt(int c)
 {
 	static char buf[MAX_PRCHAR_LEN+2];
 
@@ -65,9 +63,8 @@ propt(c)
  * Scan an argument (either from the command line or from the 
  * LESS environment variable) and process it.
  */
-	public void
-scan_option(s)
-	char *s;
+	public void 
+scan_option(char *s)
 {
 	struct loption *o;
 	int optc;
@@ -301,12 +298,8 @@ scan_option(s)
  *      OPT_UNSET       set to the default value
  *      OPT_SET         set to the inverse of the default value
  */
-	public void
-toggle_option(o, lower, s, how_toggle)
-	struct loption *o;
-	int lower;
-	char *s;
-	int how_toggle;
+	public void 
+toggle_option(struct loption *o, int lower, char *s, int how_toggle)
 {
 	int num;
 	int no_prompt;
@@ -487,10 +480,8 @@ toggle_option(o, lower, s, how_toggle)
 /*
  * "Toggle" a triple-valued option.
  */
-	static int
-flip_triple(val, lc)
-	int val;
-	int lc;
+	static int 
+flip_triple(int val, int lc)
 {
 	if (lc)
 		return ((val == OPT_ON) ? OPT_OFF : OPT_ON);
@@ -501,9 +492,8 @@ flip_triple(val, lc)
 /*
  * Determine if an option takes a parameter.
  */
-	public int
-opt_has_param(o)
-	struct loption *o;
+	public int 
+opt_has_param(struct loption *o)
 {
 	if (o == NULL)
 		return (0);
@@ -517,8 +507,7 @@ opt_has_param(o)
  * Only string and number valued options have prompts.
  */
 	public char *
-opt_prompt(o)
-	struct loption *o;
+opt_prompt(struct loption *o)
 {
 	if (o == NULL || (o->otype & (STRING|NUMBER)) == 0)
 		return ("?");
@@ -530,8 +519,7 @@ opt_prompt(o)
  * Otherwise return an appropriate error message.
  */
 	public char *
-opt_toggle_disallowed(c)
-	int c;
+opt_toggle_disallowed(int c)
 {
 	switch (c)
 	{
@@ -559,9 +547,8 @@ isoptpending(VOID_PARAM)
 /*
  * Print error message about missing string.
  */
-	static void
-nostring(printopt)
-	char *printopt;
+	static void 
+nostring(char *printopt)
 {
 	PARG parg;
 	parg.p_string = printopt;
@@ -583,11 +570,7 @@ nopendopt(VOID_PARAM)
  * Return a pointer to the remainder of the string, if any.
  */
 	static char *
-optstring(s, p_str, printopt, validchars)
-	char *s;
-	char **p_str;
-	char *printopt;
-	char *validchars;
+optstring(char *s, char **p_str, char *printopt, char *validchars)
 {
 	char *p;
 	char *out;
@@ -622,10 +605,8 @@ optstring(s, p_str, printopt, validchars)
 
 /*
  */
-	static int
-num_error(printopt, errp)
-	char *printopt;
-	int *errp;
+	static int 
+num_error(char *printopt, int *errp)
 {
 	PARG parg;
 
@@ -647,11 +628,8 @@ num_error(printopt, errp)
  * Like atoi(), but takes a pointer to a char *, and updates
  * the char * to point after the translated number.
  */
-	public int
-getnum(sp, printopt, errp)
-	char **sp;
-	char *printopt;
-	int *errp;
+	public int 
+getnum(char **sp, char *printopt, int *errp)
 {
 	char *s;
 	int n;
@@ -684,11 +662,8 @@ getnum(sp, printopt, errp)
  * The value of the fraction is returned as parts per NUM_FRAC_DENOM.
  * That is, if "n" is returned, the fraction intended is n/NUM_FRAC_DENOM.
  */
-	public long
-getfraction(sp, printopt, errp)
-	char **sp;
-	char *printopt;
-	int *errp;
+	public long 
+getfraction(char **sp, char *printopt, int *errp)
 {
 	char *s;
 	long frac = 0;

--- a/opttbl.c
+++ b/opttbl.c
@@ -675,8 +675,7 @@ init_option(VOID_PARAM)
  * Find an option in the option table, given its option letter.
  */
 	public struct loption *
-findopt(c)
-	int c;
+findopt(int c)
 {
 	struct loption *o;
 
@@ -693,9 +692,8 @@ findopt(c)
 /*
  *
  */
-	static int
-is_optchar(c)
-	char c;
+	static int 
+is_optchar(int c)
 {
 	if (ASCII_IS_UPPER(c))
 		return 1;
@@ -713,10 +711,7 @@ is_optchar(c)
  * p_oname if non-NULL is set to point to the full option name.
  */
 	public struct loption *
-findopt_name(p_optname, p_oname, p_err)
-	char **p_optname;
-	char **p_oname;
-	int *p_err;
+findopt_name(char **p_optname, char **p_oname, int *p_err)
 {
 	char *optname = *p_optname;
 	struct loption *o;

--- a/os.c
+++ b/os.c
@@ -100,10 +100,8 @@ init_poll(VOID_PARAM)
  * Return READ_INTR to abort F command (forw_loop).
  * Return 0 if safe to read from fd.
  */
-	static int
-check_poll(fd, tty)
-	int fd;
-	int tty;
+	static int 
+check_poll(int fd, int tty)
 {
 	struct pollfd poller[2] = { { fd, POLLIN, 0 }, { tty, POLLIN, 0 } };
 	int timeout = (waiting_for_data && follow_mode != FOLLOW_NAME) ? -1 : 10;
@@ -147,11 +145,8 @@ supports_ctrl_x(VOID_PARAM)
  * A call to intread() from a signal handler will interrupt
  * any pending iread().
  */
-	public int
-iread(fd, buf, len)
-	int fd;
-	unsigned char *buf;
-	unsigned int len;
+	public int 
+iread(int fd, unsigned char *buf, unsigned int len)
 {
 	int n;
 
@@ -312,8 +307,7 @@ get_time(VOID_PARAM)
  * Local version of strerror, if not available from the system.
  */
 	static char *
-strerror(err)
-	int err;
+strerror(int err)
 {
 	static char buf[INT_STRLEN_BOUND(int)+12];
 #if HAVE_SYS_ERRLIST
@@ -332,8 +326,7 @@ strerror(err)
  * errno_message: Return an error message based on the value of "errno".
  */
 	public char *
-errno_message(filename)
-	char *filename;
+errno_message(char *filename)
 {
 	char *p;
 	char *m;
@@ -354,9 +347,8 @@ errno_message(filename)
 
 /* #define HAVE_FLOAT 0 */
 
-	static POSITION
-muldiv(val, num, den)
-	POSITION val, num, den;
+	static POSITION 
+muldiv(POSITION val, POSITION num, POSITION den)
 {
 #if HAVE_FLOAT
 	double v = (((double) val) * num) / den;
@@ -378,10 +370,8 @@ muldiv(val, num, den)
  * Return the ratio of two POSITIONS, as a percentage.
  * {{ Assumes a POSITION is a long int. }}
  */
-	public int
-percentage(num, den)
-	POSITION num;
-	POSITION den;
+	public int 
+percentage(POSITION num, POSITION den)
 {
 	return (int) muldiv(num,  (POSITION) 100, den);
 }
@@ -389,11 +379,8 @@ percentage(num, den)
 /*
  * Return the specified percentage of a POSITION.
  */
-	public POSITION
-percent_pos(pos, percent, fraction)
-	POSITION pos;
-	int percent;
-	long fraction;
+	public POSITION 
+percent_pos(POSITION pos, int percent, long fraction)
 {
 	/* Change percent (parts per 100) to perden (parts per NUM_FRAC_DENOM). */
 	POSITION perden = (percent * (NUM_FRAC_DENOM / 100)) + (fraction / 100);
@@ -408,9 +395,7 @@ percent_pos(pos, percent, fraction)
  * strchr is used by regexp.c.
  */
 	char *
-strchr(s, c)
-	char *s;
-	int c;
+strchr(char *s, int c)
 {
 	for ( ;  *s != '\0';  s++)
 		if (*s == c)
@@ -444,9 +429,7 @@ memcpy(dst, src, len)
  * This implements an ANSI-style intercept setup for Microware C 3.2
  */
 	public int 
-os9_signal(type, handler)
-	int type;
-	RETSIGTYPE (*handler)();
+os9_signal(int type, RETSIGTYPE (*handler)())
 {
 	intercept(handler);
 }
@@ -454,8 +437,7 @@ os9_signal(type, handler)
 #include <sgstat.h>
 
 	int 
-isatty(f)
-	int f;
+isatty(int f)
 {
 	struct sgbuf sgbuf;
 
@@ -466,9 +448,8 @@ isatty(f)
 	
 #endif
 
-	public void
-sleep_ms(ms)
-	int ms;
+	public void 
+sleep_ms(int ms)
 {
 #if MSDOS_COMPILER==WIN32C
 	Sleep(ms);

--- a/output.c
+++ b/output.c
@@ -397,9 +397,8 @@ flush(VOID_PARAM)
 /*
  * Set the output file descriptor (1=stdout or 2=stderr).
  */
-	public void
-set_output(fd)
-	int fd;
+	public void 
+set_output(int fd)
 {
 	flush();
 	outfd = fd;
@@ -408,9 +407,8 @@ set_output(fd)
 /*
  * Output a character.
  */
-	public int
-putchr(c)
-	int c;
+	public int 
+putchr(int c)
 {
 #if 0 /* fake UTF-8 output for testing */
 	extern int utf_mode;
@@ -467,9 +465,8 @@ clear_bot_if_needed(VOID_PARAM)
 /*
  * Output a string.
  */
-	public void
-putstr(s)
-	constant char *s;
+	public void 
+putstr(constant char *s)
 {
 	while (*s != '\0')
 		putchr(*s++);
@@ -480,9 +477,7 @@ putstr(s)
  * Convert an integral type to a string.
  */
 #define TYPE_TO_A_FUNC(funcname, type) \
-void funcname(num, buf) \
-	type num; \
-	char *buf; \
+void funcname(type num, char *buf) \
 { \
 	int neg = (num < 0); \
 	char tbuf[INT_STRLEN_BOUND(num)+2]; \
@@ -504,10 +499,7 @@ TYPE_TO_A_FUNC(inttoa, int)
  * Convert an string to an integral type.
  */
 #define STR_TO_TYPE_FUNC(funcname, type) \
-type funcname(buf, ebuf, radix) \
-	char *buf; \
-	char **ebuf; \
-	int radix; \
+type funcname(char *buf, char **ebuf, int radix) \
 { \
 	type val = 0; \
 	for (;; buf++) { \
@@ -528,8 +520,7 @@ STR_TO_TYPE_FUNC(lstrtoul, unsigned long)
  * Output an integer in a given radix.
  */
 	static int
-iprint_int(num)
-	int num;
+iprint_int(int num)
 {
 	char buf[INT_STRLEN_BOUND(num)];
 
@@ -541,9 +532,8 @@ iprint_int(num)
 /*
  * Output a line number in a given radix.
  */
-	static int
-iprint_linenum(num)
-	LINENUM num;
+	static int 
+iprint_linenum(LINENUM num)
 {
 	char buf[INT_STRLEN_BOUND(num)];
 
@@ -559,10 +549,8 @@ iprint_linenum(num)
  * {{ This paranoia about the portability of printf dates from experiences
  *    with systems in the 1980s and is of course no longer necessary. }}
  */
-	public int
-less_printf(fmt, parg)
-	char *fmt;
-	PARG *parg;
+	public int 
+less_printf(char *fmt, PARG *parg)
 {
 	char *s;
 	int col;
@@ -638,10 +626,8 @@ get_return(VOID_PARAM)
  * Output a message in the lower left corner of the screen
  * and wait for carriage return.
  */
-	public void
-error(fmt, parg)
-	char *fmt;
-	PARG *parg;
+	public void 
+error(char *fmt, PARG *parg)
 {
 	int col = 0;
 	static char return_to_continue[] = "  (press RETURN)";
@@ -687,11 +673,8 @@ error(fmt, parg)
  * Usually used to warn that we are beginning a potentially
  * time-consuming operation.
  */
-	static void
-ierror_suffix(fmt, suffix, parg)
-	char *fmt;
-	char *suffix;
-	PARG *parg;
+	static void 
+ierror_suffix(char *fmt, char *suffix, PARG *parg)
 {
 	at_exit();
 	clear_bot();
@@ -703,19 +686,15 @@ ierror_suffix(fmt, suffix, parg)
 	need_clr = 1;
 }
 
-	public void
-ierror(fmt, parg)
-	char *fmt;
-	PARG *parg;
+	public void 
+ierror(char *fmt, PARG *parg)
 {
 	static char suffix[] = "... (interrupt to abort)";
 	ierror_suffix(fmt, suffix, parg);
 }
 
-	public void
-ixerror(fmt, parg)
-	char *fmt;
-	PARG *parg;
+	public void 
+ixerror(char *fmt, PARG *parg)
 {
 	if (!supports_ctrl_x())
 		ierror(fmt, parg);
@@ -730,10 +709,8 @@ ixerror(fmt, parg)
  * Output a message in the lower left corner of the screen
  * and return a single-character response.
  */
-	public int
-query(fmt, parg)
-	char *fmt;
-	PARG *parg;
+	public int 
+query(char *fmt, PARG *parg)
 {
 	int c;
 	int col = 0;

--- a/pattern.c
+++ b/pattern.c
@@ -20,12 +20,8 @@ extern int utf_mode;
 /*
  * Compile a search pattern, for future use by match_pattern.
  */
-	static int
-compile_pattern2(pattern, search_type, comp_pattern, show_error)
-	char *pattern;
-	int search_type;
-	PATTERN_TYPE *comp_pattern;
-	int show_error;
+	static int 
+compile_pattern2(char *pattern, int search_type, PATTERN_TYPE *comp_pattern, int show_error)
 {
 	if (search_type & SRCH_NO_REGEX)
 		return (0);
@@ -147,12 +143,8 @@ compile_pattern2(pattern, search_type, comp_pattern, show_error)
 /*
  * Like compile_pattern2, but convert the pattern to lowercase if necessary.
  */
-	public int
-compile_pattern(pattern, search_type, show_error, comp_pattern)
-	char *pattern;
-	int search_type;
-	int show_error;
-	PATTERN_TYPE *comp_pattern;
+	public int 
+compile_pattern(char *pattern, int search_type, int show_error, PATTERN_TYPE *comp_pattern)
 {
 	char *cvt_pattern;
 	int result;
@@ -173,9 +165,8 @@ compile_pattern(pattern, search_type, show_error, comp_pattern)
 /*
  * Forget that we have a compiled pattern.
  */
-	public void
-uncompile_pattern(pattern)
-	PATTERN_TYPE *pattern;
+	public void 
+uncompile_pattern(PATTERN_TYPE *pattern)
 {
 #if HAVE_GNU_REGEX
 	if (*pattern != NULL)
@@ -222,9 +213,8 @@ uncompile_pattern(pattern)
 /*
  * Can a pattern be successfully compiled?
  */
-	public int
-valid_pattern(pattern)
-	char *pattern;
+	public int 
+valid_pattern(char *pattern)
 {
 	PATTERN_TYPE comp_pattern;
 	int result;
@@ -241,9 +231,8 @@ valid_pattern(pattern)
 /*
  * Is a compiled pattern null?
  */
-	public int
-is_null_pattern(pattern)
-	PATTERN_TYPE pattern;
+	public int 
+is_null_pattern(PATTERN_TYPE pattern)
 {
 #if HAVE_GNU_REGEX
 	return (pattern == NULL);
@@ -275,13 +264,8 @@ is_null_pattern(pattern)
  * Simple pattern matching function.
  * It supports no metacharacters like *, etc.
  */
-	static int
-match(pattern, pattern_len, buf, buf_len, pfound, pend)
-	char *pattern;
-	int pattern_len;
-	char *buf;
-	int buf_len;
-	char **pfound, **pend;
+	static int 
+match(char *pattern, int pattern_len, char *buf, int buf_len, char **pfound, char **pend)
 {
 	char *pp, *lp;
 	char *pattern_end = pattern + pattern_len;
@@ -316,16 +300,8 @@ match(pattern, pattern_len, buf, buf_len, pfound, pend)
  * Perform a pattern match with the previously compiled pattern.
  * Set sp and ep to the start and end of the matched string.
  */
-	public int
-match_pattern(pattern, tpattern, line, line_len, sp, ep, notbol, search_type)
-	PATTERN_TYPE pattern;
-	char *tpattern;
-	char *line;
-	int line_len;
-	char **sp;
-	char **ep;
-	int notbol;
-	int search_type;
+	public int 
+match_pattern(PATTERN_TYPE pattern, char *tpattern, char *line, int line_len, char **sp, char **ep, int notbol, int search_type)
 {
 	int matched;
 

--- a/position.c
+++ b/position.c
@@ -36,9 +36,8 @@ extern int header_lines;
  *      the bottom line on the screen
  *      the line after the bottom line on the screen
  */
-	public POSITION
-position(sindex)
-	int sindex;
+	public POSITION 
+position(int sindex)
 {
 	switch (sindex)
 	{
@@ -58,9 +57,8 @@ position(sindex)
 /*
  * Add a new file position to the bottom of the position table.
  */
-	public void
-add_forw_pos(pos)
-	POSITION pos;
+	public void 
+add_forw_pos(POSITION pos)
 {
 	int i;
 
@@ -75,9 +73,8 @@ add_forw_pos(pos)
 /*
  * Add a new file position to the top of the position table.
  */
-	public void
-add_back_pos(pos)
-	POSITION pos;
+	public void 
+add_back_pos(POSITION pos)
 {
 	int i;
 
@@ -133,9 +130,8 @@ pos_init(VOID_PARAM)
  * Check the position table to see if the position falls within its range.
  * Return the position table entry if found, -1 if not.
  */
-	public int
-onscreen(pos)
-	POSITION pos;
+	public int 
+onscreen(POSITION pos)
 {
 	int i;
 
@@ -156,10 +152,8 @@ empty_screen(VOID_PARAM)
 	return (empty_lines(0, sc_height-1));
 }
 
-	public int
-empty_lines(s, e)
-	int s;
-	int e;
+	public int 
+empty_lines(int s, int e)
 {
 	int i;
 
@@ -177,10 +171,8 @@ empty_lines(s, e)
  * such that the top few lines are empty, we may have to set
  * the screen line to a number > 0.
  */
-	public void
-get_scrpos(scrpos, where)
-	struct scrpos *scrpos;
-	int where;
+	public void 
+get_scrpos(struct scrpos *scrpos, int where)
 {
 	int i;
 	int dir;
@@ -233,9 +225,8 @@ get_scrpos(scrpos, where)
  * or it may be in { -1 .. -(sc_height-1) } to refer to lines
  * relative to the bottom of the screen.
  */
-	public int
-sindex_from_sline(sline)
-	int sline;
+	public int 
+sindex_from_sline(int sline)
 {
 	/*
 	 * Negative screen line number means

--- a/prompt.c
+++ b/prompt.c
@@ -80,9 +80,8 @@ init_prompt(VOID_PARAM)
 /*
  * Append a string to the end of the message.
  */
-	static void
-ap_str(s)
-	char *s;
+	static void 
+ap_str(char *s)
 {
 	int len;
 
@@ -97,9 +96,8 @@ ap_str(s)
 /*
  * Append a character to the end of the message.
  */
-	static void
-ap_char(c)
-	char c;
+	static void 
+ap_char(int c)
 {
 	char buf[2];
 
@@ -111,9 +109,8 @@ ap_char(c)
 /*
  * Append a POSITION (as a decimal integer) to the end of the message.
  */
-	static void
-ap_pos(pos)
-	POSITION pos;
+	static void 
+ap_pos(POSITION pos)
 {
 	char buf[INT_STRLEN_BOUND(pos) + 2];
 
@@ -124,9 +121,8 @@ ap_pos(pos)
 /*
  * Append a line number to the end of the message.
  */
-	static void
-ap_linenum(linenum)
-	LINENUM linenum;
+	static void 
+ap_linenum(LINENUM linenum)
 {
 	char buf[INT_STRLEN_BOUND(linenum) + 2];
 
@@ -137,9 +133,8 @@ ap_linenum(linenum)
 /*
  * Append an integer to the end of the message.
  */
-	static void
-ap_int(num)
-	int num;
+	static void 
+ap_int(int num)
 {
 	char buf[INT_STRLEN_BOUND(num) + 2];
 
@@ -159,9 +154,8 @@ ap_quest(VOID_PARAM)
 /*
  * Return the "current" byte offset in the file.
  */
-	static POSITION
-curr_byte(where)
-	int where;
+	static POSITION 
+curr_byte(int where)
 {
 	POSITION pos;
 
@@ -179,10 +173,8 @@ curr_byte(where)
  * question mark followed by a single letter.
  * Here we decode that letter and return the appropriate boolean value.
  */
-	static int
-cond(c, where)
-	char c;
-	int where;
+	static int 
+cond(int c, int where)
 {
 	POSITION len;
 
@@ -246,11 +238,8 @@ cond(c, where)
  * Here we decode that letter and take the appropriate action,
  * usually by appending something to the message being built.
  */
-	static void
-protochar(c, where, iseditproto)
-	int c;
-	int where;
-	int iseditproto;
+	static void 
+protochar(int c, int where, int iseditproto)
 {
 	POSITION pos;
 	POSITION len;
@@ -403,8 +392,7 @@ protochar(c, where, iseditproto)
  * We must keep track of nested IFs and skip them properly.
  */
 	static constant char *
-skipcond(p)
-	constant char *p;
+skipcond(constant char *p)
 {
 	int iflevel;
 
@@ -461,9 +449,7 @@ skipcond(p)
  * Decode a char that represents a position on the screen.
  */
 	static constant char *
-wherechar(p, wp)
-	char constant *p;
-	int *wp;
+wherechar(char constant *p, int *wp)
 {
 	switch (*p)
 	{
@@ -485,8 +471,7 @@ wherechar(p, wp)
  * Construct a message based on a prototype string.
  */
 	public char *
-pr_expand(proto)
-	constant char *proto;
+pr_expand(constant char *proto)
 {
 	constant char *p;
 	int c;

--- a/regexp.c
+++ b/regexp.c
@@ -207,8 +207,7 @@ STATIC int strcspn();
  * of the structure of the compiled regexp.
  */
 regexp *
-regcomp(exp)
-char *exp;
+regcomp(char *exp)
 {
 	register regexp *r;
 	register char *scan;
@@ -297,9 +296,10 @@ char *exp;
  * follows makes it hard to avoid.
  */
 static char *
-reg(paren, flagp)
-int paren;			/* Parenthesized? */
-int *flagp;
+reg (
+    int paren,			/* Parenthesized? */
+    int *flagp
+)
 {
 	register char *ret;
 	register char *br;
@@ -369,8 +369,7 @@ int *flagp;
  * Implements the concatenation operator.
  */
 static char *
-regbranch(flagp)
-int *flagp;
+regbranch(int *flagp)
 {
 	register char *ret;
 	register char *chain;
@@ -408,8 +407,7 @@ int *flagp;
  * endmarker role is not redundant.
  */
 static char *
-regpiece(flagp)
-int *flagp;
+regpiece(int *flagp)
 {
 	register char *ret;
 	register char op;
@@ -472,8 +470,7 @@ int *flagp;
  * separate node; the code is simpler that way and it's not worth fixing.
  */
 static char *
-regatom(flagp)
-int *flagp;
+regatom(int *flagp)
 {
 	register char *ret;
 	int flags;
@@ -582,9 +579,8 @@ int *flagp;
 /*
  - regnode - emit a node
  */
-static char *			/* Location. */
-regnode(op)
-char op;
+static char *
+regnode(int op)
 {
 	register char *ret;
 	register char *ptr;
@@ -607,9 +603,8 @@ char op;
 /*
  - regc - emit (if appropriate) a byte of code
  */
-static void
-regc(b)
-char b;
+static void 
+regc(int b)
 {
 	if (regcode != &regdummy)
 		*regcode++ = b;
@@ -622,10 +617,8 @@ char b;
  *
  * Means relocating the operand.
  */
-static void
-reginsert(op, opnd)
-char op;
-char *opnd;
+static void 
+reginsert(int op, char *opnd)
 {
 	register char *src;
 	register char *dst;
@@ -651,10 +644,8 @@ char *opnd;
 /*
  - regtail - set the next-pointer at the end of a node chain
  */
-static void
-regtail(p, val)
-char *p;
-char *val;
+static void 
+regtail(char *p, char *val)
 {
 	register char *scan;
 	register char *temp;
@@ -683,10 +674,8 @@ char *val;
 /*
  - regoptail - regtail on operand of first argument; nop if operandless
  */
-static void
-regoptail(p, val)
-char *p;
-char *val;
+static void 
+regoptail(char *p, char *val)
 {
 	/* "Operandless" and "op != BRANCH" are synonymous in practice. */
 	if (p == NULL || p == &regdummy || OP(p) != BRANCH)
@@ -722,11 +711,8 @@ STATIC char *regprop();
 /*
  - regexec - match a regexp against a string
  */
-int
-regexec2(prog, string, notbol)
-register regexp *prog;
-register char *string;
-int notbol;
+int 
+regexec2(register regexp *prog, register char *string, int notbol)
 {
 	register char *s;
 
@@ -784,10 +770,8 @@ int notbol;
 	return(0);
 }
 
-int
-regexec(prog, string)
-register regexp *prog;
-register char *string;
+int 
+regexec(register regexp *prog, register char *string)
 {
 	return regexec2(prog, string, 0);
 }
@@ -795,10 +779,8 @@ register char *string;
 /*
  - regtry - try match at specific point
  */
-static int			/* 0 failure, 1 success */
-regtry(prog, string)
-regexp *prog;
-char *string;
+static int 
+regtry(regexp *prog, char *string)
 {
 	register int i;
 	register char **sp;
@@ -832,9 +814,8 @@ char *string;
  * need to know whether the rest of the match failed) by a loop instead of
  * by recursion.
  */
-static int			/* 0 failure, 1 success */
-regmatch(prog)
-char *prog;
+static int 
+regmatch(char *prog)
 {
 	register char *scan;	/* Current node. */
 	char *next;		/* Next node. */
@@ -1025,9 +1006,8 @@ char *prog;
 /*
  - regrepeat - repeatedly match something simple, report how many
  */
-static int
-regrepeat(p)
-char *p;
+static int 
+regrepeat(char *p)
 {
 	register int count = 0;
 	register char *scan;
@@ -1072,8 +1052,7 @@ char *p;
  - regnext - dig the "next" pointer out of a node
  */
 static char *
-regnext(p)
-register char *p;
+regnext(register char *p)
 {
 	register int offset;
 
@@ -1097,9 +1076,8 @@ STATIC char *regprop();
 /*
  - regdump - dump a regexp onto stdout in vaguely comprehensible form
  */
-void
-regdump(r)
-regexp *r;
+void 
+regdump(regexp *r)
 {
 	register char *s;
 	register char op = EXACTLY;	/* Arbitrary non-END op. */
@@ -1141,8 +1119,7 @@ regexp *r;
  - regprop - printable representation of opcode
  */
 static char *
-regprop(op)
-char *op;
+regprop(char *op)
 {
 	register char *p;
 	static char buf[50];
@@ -1232,10 +1209,8 @@ char *op;
  * of characters not from s2
  */
 
-static int
-strcspn(s1, s2)
-char *s1;
-char *s2;
+static int 
+strcspn(char *s1, char *s2)
 {
 	register char *scan1;
 	register char *scan2;

--- a/screen.c
+++ b/screen.c
@@ -302,12 +302,12 @@ extern char *tgoto();
 /*
  * Set termio flags for use by less.
  */
-	static void
-set_termio_flags(s)
 #if HAVE_TERMIOS_H && HAVE_TERMIOS_FUNCS
-	struct termios *s;
+	static void
+set_termio_flags(struct termios *s)
 #else
-	struct termio *s;
+	static void
+set_termio_flags(struct termio *s)
 #endif
 {
 	s->c_lflag &= ~(0
@@ -376,9 +376,8 @@ set_termio_flags(s)
  *         etc. are NOT disabled.
  * It doesn't matter whether an input \n is mapped to \r, or vice versa.
  */
-	public void
-raw_mode(on)
-	int on;
+	public void 
+raw_mode(int on)
 {
 	static int curr_on = 0;
 
@@ -704,8 +703,7 @@ raw_mode(on)
 static int hardcopy;
 
 	static char *
-ltget_env(capname)
-	char *capname;
+ltget_env(char *capname)
 {
 	char name[64];
 
@@ -729,9 +727,8 @@ ltget_env(capname)
 	return (lgetenv(name));
 }
 
-	static int
-ltgetflag(capname)
-	char *capname;
+	static int 
+ltgetflag(char *capname)
 {
 	char *s;
 
@@ -742,9 +739,8 @@ ltgetflag(capname)
 	return (tgetflag(capname));
 }
 
-	static int
-ltgetnum(capname)
-	char *capname;
+	static int 
+ltgetnum(char *capname)
 {
 	char *s;
 
@@ -756,9 +752,7 @@ ltgetnum(capname)
 }
 
 	static char *
-ltgetstr(capname, pp)
-	char *capname;
-	char **pp;
+ltgetstr(char *capname, char **pp)
 {
 	char *s;
 
@@ -936,9 +930,8 @@ get_clock(VOID_PARAM)
 /*
  * Delay for a specified number of milliseconds.
  */
-	static void
-delay(msec)
-	int msec;
+	static void 
+delay(int msec)
 {
 	long i;
 	
@@ -954,8 +947,7 @@ delay(msec)
  * Return the characters actually input by a "special" key.
  */
 	public char *
-special_key_str(key)
-	int key;
+special_key_str(int key)
 {
 	static char tbuf[40];
 	char *s;
@@ -1447,17 +1439,15 @@ get_term(VOID_PARAM)
 static int costcount;
 
 /*ARGSUSED*/
-	static int
-inc_costcount(c)
-	int c;
+	static int 
+inc_costcount(int c)
 {
 	costcount++;
 	return (c);
 }
 
-	static int
-cost(t)
-	char *t;
+	static int 
+cost(char *t)
 {
 	costcount = 0;
 	tputs(t, sc_height, inc_costcount);
@@ -1470,9 +1460,7 @@ cost(t)
  * cost (see cost() function).
  */
 	static char *
-cheaper(t1, t2, def)
-	char *t1, *t2;
-	char *def;
+cheaper(char *t1, char *t2, char *def)
 {
 	if (*t1 == '\0' && *t2 == '\0')
 	{
@@ -1488,15 +1476,8 @@ cheaper(t1, t2, def)
 	return (t2);
 }
 
-	static void
-tmodes(incap, outcap, instr, outstr, def_instr, def_outstr, spp)
-	char *incap;
-	char *outcap;
-	char **instr;
-	char **outstr;
-	char *def_instr;
-	char *def_outstr;
-	char **spp;
+	static void 
+tmodes(char *incap, char *outcap, char **instr, char **outstr, char *def_instr, char *def_outstr, char **spp)
 {
 	*instr = ltgetstr(incap, spp);
 	if (*instr == NULL)
@@ -1657,11 +1638,8 @@ win32_deinit_term(VOID_PARAM)
 #endif
 
 #if !MSDOS_COMPILER
-	static void
-do_tputs(str, affcnt, f_putc)
-	char *str;
-	int affcnt;
-	int (*f_putc)(int);
+	static void 
+do_tputs(char *str, int affcnt, int (*f_putc)(int))
 {
 #if LESSTEST
 	if (ttyin_name != NULL && f_putc == putchr)
@@ -1675,11 +1653,8 @@ do_tputs(str, affcnt, f_putc)
  * Like tputs but we handle $<...> delay strings here because
  * some implementations of tputs don't perform delays correctly.
  */
-	static void
-ltputs(str, affcnt, f_putc)
-	char *str;
-	int affcnt;
-	int (*f_putc)(int);
+	static void 
+ltputs(char *str, int affcnt, int (*f_putc)(int))
 {
 	while (str != NULL && *str != '\0')
 	{
@@ -1960,9 +1935,8 @@ add_line(VOID_PARAM)
  * window upward.  This is needed to stop leaking the topmost line 
  * into the scrollback buffer when we go down-one-line (in WIN32).
  */
-	public void
-remove_top(n)
-	int n;
+	public void 
+remove_top(int n)
 {
 #if MSDOS_COMPILER==WIN32C
 	SMALL_RECT rcSrc, rcClip;
@@ -2045,9 +2019,8 @@ win32_clear(VOID_PARAM)
  * Remove the n topmost lines and scroll everything below it in the 
  * window upward.
  */
-	public void
-win32_scroll_up(n)
-	int n;
+	public void 
+win32_scroll_up(int n)
 {
 	SMALL_RECT rcSrc, rcClip;
 	CHAR_INFO fillchar;
@@ -2191,9 +2164,8 @@ check_winch(VOID_PARAM)
 /*
  * Goto a specific line on the screen.
  */
-	public void
-goto_line(sindex)
-	int sindex;
+	public void 
+goto_line(int sindex)
 {
 	assert_interactive();
 #if !MSDOS_COMPILER
@@ -2485,9 +2457,8 @@ clear_bot(VOID_PARAM)
 /*
  * Parse a 4-bit color char.
  */
-	static int
-parse_color4(ch)
-	char ch;
+	static int 
+parse_color4(int ch)
 {
 	switch (ch)
 	{
@@ -2515,9 +2486,8 @@ parse_color4(ch)
 /*
  * Parse a color as a decimal integer.
  */
-	static int
-parse_color6(ps)
-	char **ps;
+	static int 
+parse_color6(char **ps)
 {
 	if (**ps == '-')
 	{
@@ -2539,11 +2509,8 @@ parse_color6(ps)
  *  CV_4BIT: fg/bg values are OR of CV_{RGB} bits.
  *  CV_6BIT: fg/bg values are integers entered by user.
  */
-	public COLOR_TYPE
-parse_color(str, p_fg, p_bg)
-	char *str;
-	int *p_fg;
-	int *p_bg;
+	public COLOR_TYPE 
+parse_color(char *str, int *p_fg, int *p_bg)
 {
 	int fg;
 	int bg;
@@ -2572,9 +2539,8 @@ parse_color(str, p_fg, p_bg)
 
 #if !MSDOS_COMPILER
 
-	static int
-sgr_color(color)
-	int color;
+	static int 
+sgr_color(int color)
 {
 	switch (color)
 	{
@@ -2600,11 +2566,8 @@ sgr_color(color)
 	}
 }
 
-	static void
-tput_fmt(fmt, color, f_putc)
-	char *fmt;
-	int color;
-	int (*f_putc)(int);
+	static void 
+tput_fmt(char *fmt, int color, int (*f_putc)(int))
 {
 	char buf[INT_STRLEN_BOUND(int)+16];
 	if (color == attrcolor)
@@ -2614,10 +2577,8 @@ tput_fmt(fmt, color, f_putc)
 	attrcolor = color;
 }
 
-	static void
-tput_color(str, f_putc)
-	char *str;
-	int (*f_putc)(int);
+	static void 
+tput_color(char *str, int (*f_putc)(int))
 {
 	int fg;
 	int bg;
@@ -2647,12 +2608,8 @@ tput_color(str, f_putc)
 	}
 }
 
-	static void
-tput_inmode(mode_str, attr, attr_bit, f_putc)
-	char *mode_str;
-	int attr;
-	int attr_bit;
-	int (*f_putc)(int);
+	static void 
+tput_inmode(char *mode_str, int attr, int attr_bit, int (*f_putc)(int))
 {
 	char *color_str;
 	if ((attr & attr_bit) == 0)
@@ -2668,11 +2625,8 @@ tput_inmode(mode_str, attr, attr_bit, f_putc)
 	tput_color(color_str, f_putc);
 }
 
-	static void
-tput_outmode(mode_str, attr_bit, f_putc)
-	char *mode_str;
-	int attr_bit;
-	int (*f_putc)(int);
+	static void 
+tput_outmode(char *mode_str, int attr_bit, int (*f_putc)(int))
 {
 	if ((attrmode & attr_bit) == 0)
 		return;
@@ -2682,10 +2636,8 @@ tput_outmode(mode_str, attr_bit, f_putc)
 #else /* MSDOS_COMPILER */
 
 #if MSDOS_COMPILER==WIN32C
-	static int
-WIN32put_fmt(fmt, color)
-	char *fmt;
-	int color;
+	static int 
+WIN32put_fmt(char *fmt, int color)
 {
 	char buf[INT_STRLEN_BOUND(int)+16];
 	int len = SNPRINTF1(buf, sizeof(buf), fmt, color);
@@ -2694,9 +2646,8 @@ WIN32put_fmt(fmt, color)
 }
 #endif
 
-	static int
-win_set_color(attr)
-	int attr;
+	static int 
+win_set_color(int attr)
 {
 	int fg;
 	int bg;
@@ -2740,9 +2691,8 @@ win_set_color(attr)
 
 #endif /* MSDOS_COMPILER */
 
-	public void
-at_enter(attr)
-	int attr;
+	public void 
+at_enter(int attr)
 {
 	attr = apply_at_specials(attr);
 #if !MSDOS_COMPILER
@@ -2795,9 +2745,8 @@ at_exit(VOID_PARAM)
 	attrmode = AT_NORMAL;
 }
 
-	public void
-at_switch(attr)
-	int attr;
+	public void 
+at_switch(int attr)
 {
 	int new_attrmode = apply_at_specials(attr);
 	int ignore_modes = AT_ANSI;
@@ -2809,10 +2758,8 @@ at_switch(attr)
 	}
 }
 
-	public int
-is_at_equiv(attr1, attr2)
-	int attr1;
-	int attr2;
+	public int 
+is_at_equiv(int attr1, int attr2)
 {
 	attr1 = apply_at_specials(attr1);
 	attr2 = apply_at_specials(attr2);
@@ -2820,9 +2767,8 @@ is_at_equiv(attr1, attr2)
 	return (attr1 == attr2);
 }
 
-	public int
-apply_at_specials(attr)
-	int attr;
+	public int 
+apply_at_specials(int attr)
 {
 	if (attr & AT_BINARY)
 		attr |= binattr;
@@ -3048,20 +2994,16 @@ WIN32getch(VOID_PARAM)
 #if MSDOS_COMPILER
 /*
  */
-	public void
-WIN32setcolors(fg, bg)
-	int fg;
-	int bg;
+	public void 
+WIN32setcolors(int fg, int bg)
 {
 	SETCOLORS(fg, bg);
 }
 
 /*
  */
-	public void
-WIN32textout(text, len)
-	char *text;
-	int len;
+	public void 
+WIN32textout(char *text, int len)
 {
 #if MSDOS_COMPILER==WIN32C
 	DWORD written;

--- a/scrsize.c
+++ b/scrsize.c
@@ -79,9 +79,8 @@ static int get_winsize(dpy, window, p_width, p_height)
 	return 0;
 }
 
-int main(argc, argv)
-	int argc;
-	char *argv[];
+int 
+main(int argc, char *argv[])
 {
 	char *cp;
 	Display *dpy;

--- a/search.c
+++ b/search.c
@@ -124,9 +124,8 @@ public int is_caseless;
 /*
  * Are there any uppercase letters in this string?
  */
-	static int
-is_ucase(str)
-	char *str;
+	static int 
+is_ucase(char *str)
 {
 	char *str_end = str + strlen(str);
 	LWCHAR ch;
@@ -143,9 +142,8 @@ is_ucase(str)
 /*
  * Discard a saved pattern.
  */
-	static void
-clear_pattern(info)
-	struct pattern_info *info;
+	static void 
+clear_pattern(struct pattern_info *info)
 {
 	if (info->text != NULL)
 		free(info->text);
@@ -158,12 +156,8 @@ clear_pattern(info)
 /*
  * Compile and save a search pattern.
  */
-	static int
-set_pattern(info, pattern, search_type, show_error)
-	struct pattern_info *info;
-	char *pattern;
-	int search_type;
-	int show_error;
+	static int 
+set_pattern(struct pattern_info *info, char *pattern, int search_type, int show_error)
 {
 	/*
 	 * Ignore case if -I is set OR
@@ -193,9 +187,8 @@ set_pattern(info, pattern, search_type, show_error)
 /*
  * Initialize saved pattern to nothing.
  */
-	static void
-init_pattern(info)
-	struct pattern_info *info;
+	static void 
+init_pattern(struct pattern_info *info)
 {
 	SET_NULL_PATTERN(info->compiled);
 	info->text = NULL;
@@ -215,9 +208,8 @@ init_search(VOID_PARAM)
 /*
  * Determine which text conversions to perform before pattern matching.
  */
-	static int
-get_cvt_ops(search_type)
-	int search_type;
+	static int 
+get_cvt_ops(int search_type)
 {
 	int ops = 0;
 
@@ -235,9 +227,8 @@ get_cvt_ops(search_type)
 /*
  * Is there a previous (remembered) search pattern?
  */
-	static int
-prev_pattern(info)
-	struct pattern_info *info;
+	static int 
+prev_pattern(struct pattern_info *info)
 {
 #if !NO_REGEX
 	if ((info->search_type & SRCH_NO_REGEX) == 0)
@@ -252,9 +243,8 @@ prev_pattern(info)
  * Repaint each line which contains highlighted text.
  * If on==0, force all hilites off.
  */
-	public void
-repaint_hilite(on)
-	int on;
+	public void 
+repaint_hilite(int on)
 {
 	int sindex;
 	POSITION pos;
@@ -346,9 +336,8 @@ clear_attn(VOID_PARAM)
 /*
  * Toggle or clear search string highlighting.
  */
-	public void
-undo_search(clear)
-	int clear;
+	public void 
+undo_search(int clear)
 {
 	clear_pattern(&search_info);
 #if HILITE_SEARCH
@@ -372,9 +361,8 @@ undo_search(clear)
 /*
  * Clear the hilite list.
  */
-	public void
-clr_hlist(anchor)
-	struct hilite_tree *anchor;
+	public void 
+clr_hlist(struct hilite_tree *anchor)
 {
 	struct hilite_storage *hls;
 	struct hilite_storage *nexthls;
@@ -406,9 +394,8 @@ clr_filter(VOID_PARAM)
 	clr_hlist(&filter_anchor);
 }
 
-	struct hilite_node*
-hlist_last(anchor)
-	struct hilite_tree *anchor;
+	struct hilite_node *
+hlist_last(struct hilite_tree *anchor)
 {
 	struct hilite_node *n = anchor->root;
 	while (n != NULL && n->right != NULL)
@@ -416,16 +403,14 @@ hlist_last(anchor)
 	return n;
 }
 
-	struct hilite_node*
-hlist_next(n)
-	struct hilite_node *n;
+	struct hilite_node *
+hlist_next(struct hilite_node *n)
 {
 	return n->next;
 }
 
-	struct hilite_node*
-hlist_prev(n)
-	struct hilite_node *n;
+	struct hilite_node *
+hlist_prev(struct hilite_node *n)
 {
 	return n->prev;
 }
@@ -436,10 +421,8 @@ hlist_prev(n)
  * to speed up subsequent searches for the same or similar positions (if
  * we return NULL, remember the last node.)
  */
-	struct hilite_node*
-hlist_find(anchor, pos)
-	struct hilite_tree *anchor;
-	POSITION pos;
+	struct hilite_node *
+hlist_find(struct hilite_tree *anchor, POSITION pos)
 {
 	struct hilite_node *n, *m;
 
@@ -529,10 +512,8 @@ hlist_find(anchor, pos)
 /*
  * Should any characters in a specified range be highlighted?
  */
-	static int
-is_hilited_range(pos, epos)
-	POSITION pos;
-	POSITION epos;
+	static int 
+is_hilited_range(POSITION pos, POSITION epos)
 {
 	struct hilite_node *n = hlist_find(&hilite_anchor, pos);
 	return (n != NULL && (epos == NULL_POSITION || epos > n->r.hl_startpos));
@@ -541,9 +522,8 @@ is_hilited_range(pos, epos)
 /* 
  * Is a line "filtered" -- that is, should it be hidden?
  */
-	public int
-is_filtered(pos)
-	POSITION pos;
+	public int 
+is_filtered(POSITION pos)
 {
 	struct hilite_node *n;
 
@@ -558,9 +538,8 @@ is_filtered(pos)
  * If pos is hidden, return the next position which isn't, otherwise
  * just return pos.
  */
-	public POSITION
-next_unfiltered(pos)
-	POSITION pos;
+	public POSITION 
+next_unfiltered(POSITION pos)
 {
 	struct hilite_node *n;
 
@@ -580,9 +559,8 @@ next_unfiltered(pos)
  * If pos is hidden, return the previous position which isn't or 0 if
  * we're filtered right to the beginning, otherwise just return pos.
  */
-	public POSITION
-prev_unfiltered(pos)
-	POSITION pos;
+	public POSITION 
+prev_unfiltered(POSITION pos)
 {
 	struct hilite_node *n;
 
@@ -606,12 +584,8 @@ prev_unfiltered(pos)
  * Should any characters in a specified range be highlighted?
  * If nohide is nonzero, don't consider hide_hilite.
  */
-	public int
-is_hilited_attr(pos, epos, nohide, p_matches)
-	POSITION pos;
-	POSITION epos;
-	int nohide;
-	int *p_matches;
+	public int 
+is_hilited_attr(POSITION pos, POSITION epos, int nohide, int *p_matches)
 {
 	int match;
 
@@ -663,9 +637,8 @@ is_hilited_attr(pos, epos, nohide, p_matches)
  * Tree node storage: get the current block of nodes if it has spare
  * capacity, or create a new one if not.
  */
-	static struct hilite_storage*
-hlist_getstorage(anchor)
-	struct hilite_tree *anchor;
+	static struct hilite_storage *
+hlist_getstorage(struct hilite_tree *anchor)
 {
 	int capacity = 1;
 	struct hilite_storage *s;
@@ -694,9 +667,8 @@ hlist_getstorage(anchor)
  * Tree node storage: retrieve a new empty node to be inserted into the
  * tree.
  */
-	static struct hilite_node*
-hlist_getnode(anchor)
-	struct hilite_tree *anchor;
+	static struct hilite_node *
+hlist_getnode(struct hilite_tree *anchor)
 {
 	struct hilite_storage *s = hlist_getstorage(anchor);
 	return &s->nodes[s->used++];
@@ -705,10 +677,8 @@ hlist_getnode(anchor)
 /*
  * Rotate the tree left around a pivot node.
  */
-	static void
-hlist_rotate_left(anchor, n)
-	struct hilite_tree *anchor;
-	struct hilite_node *n;
+	static void 
+hlist_rotate_left(struct hilite_tree *anchor, struct hilite_node *n)
 {
 	struct hilite_node *np = n->parent;
 	struct hilite_node *nr = n->right;
@@ -736,10 +706,8 @@ hlist_rotate_left(anchor, n)
 /*
  * Rotate the tree right around a pivot node.
  */
-	static void
-hlist_rotate_right(anchor, n)
-	struct hilite_tree *anchor;
-	struct hilite_node *n;
+	static void 
+hlist_rotate_right(struct hilite_tree *anchor, struct hilite_node *n)
 {
 	struct hilite_node *np = n->parent;
 	struct hilite_node *nl = n->left;
@@ -768,10 +736,8 @@ hlist_rotate_right(anchor, n)
 /*
  * Add a new hilite to a hilite list.
  */
-	static void
-add_hilite(anchor, hl)
-	struct hilite_tree *anchor;
-	struct hilite *hl;
+	static void 
+add_hilite(struct hilite_tree *anchor, struct hilite *hl)
 {
 	struct hilite_node *p, *n, *u;
 
@@ -947,12 +913,8 @@ add_hilite(anchor, hl)
 /*
  * Highlight every character in a range of displayed characters.
  */
-	static void
-create_hilites(linepos, start_index, end_index, chpos)
-	POSITION linepos;
-	int start_index;
-	int end_index;
-	int *chpos;
+	static void 
+create_hilites(POSITION linepos, int start_index, int end_index, int *chpos)
 {
 	struct hilite hl;
 	int i;
@@ -988,15 +950,8 @@ create_hilites(linepos, start_index, end_index, chpos)
  * the current pattern.
  * sp,ep delimit the first match already found.
  */
-	static void
-hilite_line(linepos, line, line_len, chpos, sp, ep, cvt_ops)
-	POSITION linepos;
-	char *line;
-	int line_len;
-	int *chpos;
-	char *sp;
-	char *ep;
-	int cvt_ops;
+	static void 
+hilite_line(POSITION linepos, char *line, int line_len, int *chpos, char *sp, char *ep, int cvt_ops)
 {
 	char *searchp;
 	char *line_end = line + line_len;
@@ -1071,9 +1026,8 @@ chg_hilite(VOID_PARAM)
 /*
  * Figure out where to start a search.
  */
-	static POSITION
-search_pos(search_type)
-	int search_type;
+	static POSITION 
+search_pos(int search_type)
 {
 	POSITION pos;
 	int sindex;
@@ -1166,15 +1120,8 @@ search_pos(search_type)
  * If so, add an entry to the filter list.
  */
 #if HILITE_SEARCH
-	static int
-matches_filters(pos, cline, line_len, chpos, linepos, sp, ep)
-	POSITION pos;
-	char *cline;
-	int line_len;
-	int *chpos;
-	POSITION linepos;
-	char **sp;
-	char **ep;
+	static int 
+matches_filters(POSITION pos, char *cline, int line_len, int *chpos, POSITION linepos, char **sp, char **ep)
 {
 	struct pattern_info *filter;
 
@@ -1201,11 +1148,8 @@ matches_filters(pos, cline, line_len, chpos, linepos, sp, ep)
  * Get the position of the first char in the screen line which
  * puts tpos on screen.
  */
-	static POSITION
-get_lastlinepos(pos, tpos, sheight)
-	POSITION pos;
-	POSITION tpos;
-	int sheight;
+	static POSITION 
+get_lastlinepos(POSITION pos, POSITION tpos, int sheight)
 {
 	int nlines;
 
@@ -1226,10 +1170,8 @@ get_lastlinepos(pos, tpos, sheight)
  * Get the segment index of tpos in the line starting at pos.
  * A segment is a string of printable chars that fills the screen width.
  */
-	static int
-get_seg(pos, tpos)
-	POSITION pos;
-	POSITION tpos;
+	static int 
+get_seg(POSITION pos, POSITION tpos)
 {
 	int seg;
 
@@ -1245,16 +1187,8 @@ get_seg(pos, tpos)
 /*
  * Search a subset of the file, specified by start/end position.
  */
-	static int
-search_range(pos, endpos, search_type, matches, maxlines, plinepos, pendpos, plastlinepos)
-	POSITION pos;
-	POSITION endpos;
-	int search_type;
-	int matches;
-	int maxlines;
-	POSITION *plinepos;
-	POSITION *pendpos;
-	POSITION *plastlinepos;
+	static int 
+search_range(POSITION pos, POSITION endpos, int search_type, int matches, int maxlines, POSITION *plinepos, POSITION *pendpos, POSITION *plastlinepos)
 {
 	char *line;
 	char *cline;
@@ -1504,8 +1438,7 @@ search_range(pos, endpos, search_type, matches, maxlines, plinepos, pendpos, pla
  * search for a pattern in history. If found, compile that pattern.
  */
 	static int 
-hist_pattern(search_type) 
-	int search_type;
+hist_pattern(int search_type)
 {
 #if CMD_HISTORY
 	char *pattern;
@@ -1567,11 +1500,8 @@ chg_caseless(VOID_PARAM)
  * Caller may continue the search in another file 
  * if less than n matches are found in this file.
  */
-	public int
-search(search_type, pattern, n)
-	int search_type;
-	char *pattern;
-	int n;
+	public int 
+search(int search_type, char *pattern, int n)
 {
 	POSITION pos;
 	POSITION opos;
@@ -1716,11 +1646,8 @@ search(search_type, pattern, n)
  * If prep_endpos == NULL_POSITION, the prep region extends to EOF.
  * prep_hilite asks that the range (spos,epos) be covered by the prep region.
  */
-	public void
-prep_hilite(spos, epos, maxlines)
-	POSITION spos;
-	POSITION epos;
-	int maxlines;
+	public void 
+prep_hilite(POSITION spos, POSITION epos, int maxlines)
 {
 	POSITION nprep_startpos = prep_startpos;
 	POSITION nprep_endpos = prep_endpos;
@@ -1886,10 +1813,8 @@ prep_hilite(spos, epos, maxlines)
 /*
  * Set the pattern to be used for line filtering.
  */
-	public void
-set_filter_pattern(pattern, search_type)
-	char *pattern;
-	int search_type;
+	public void 
+set_filter_pattern(char *pattern, int search_type)
 {
 	struct pattern_info *filter;
 
@@ -1941,8 +1866,7 @@ is_filtering(VOID_PARAM)
 public int reg_show_error = 1;
 
 	void 
-regerror(s) 
-	char *s; 
+regerror(char *s) 
 {
 	PARG parg;
 

--- a/signal.c
+++ b/signal.c
@@ -42,8 +42,7 @@ extern long jump_sline_fraction;
 #if MSDOS_COMPILER!=WIN32C
 	/* ARGSUSED*/
 	static RETSIGTYPE
-u_interrupt(type)
-	int type;
+u_interrupt(int type)
 {
 	bell();
 #if OS2
@@ -74,8 +73,7 @@ u_interrupt(type)
  */
 	/* ARGSUSED*/
 	static RETSIGTYPE
-stop(type)
-	int type;
+stop(int type)
 {
 	LSIGNAL(SIGTSTP, stop);
 	sigs |= S_STOP;
@@ -99,8 +97,7 @@ stop(type)
  */
 	/* ARGSUSED*/
 	public RETSIGTYPE
-winch(type)
-	int type;
+winch(int type)
 {
 	LSIGNAL(SIG_LESSWINDOW, winch);
 	sigs |= S_WINCH;
@@ -137,8 +134,7 @@ wbreak_handler(dwCtrlType)
 #endif
 
 	static RETSIGTYPE
-terminate(type)
-	int type;
+terminate(int type)
 {
 	quit(15);
 }
@@ -146,9 +142,8 @@ terminate(type)
 /*
  * Set up the signal handlers.
  */
-	public void
-init_signals(on)
-	int on;
+	public void 
+init_signals(int on)
 {
 	if (on)
 	{

--- a/tags.c
+++ b/tags.c
@@ -113,12 +113,7 @@ cleantags(VOID_PARAM)
  * Create a new tag entry.
  */
 	static struct tag *
-maketagent(name, file, linenum, pattern, endline)
-	char *name;
-	char *file;
-	LINENUM linenum;
-	char *pattern;
-	int endline;
+maketagent(char *name, char *file, LINENUM linenum, char *pattern, int endline)
 {
 	struct tag *tp;
 
@@ -171,9 +166,8 @@ gettagtype(VOID_PARAM)
  * and "tagpattern" to the search pattern which should be used
  * to find the tag.
  */
-	public void
-findtag(tag)
-	char *tag;
+	public void 
+findtag(char *tag)
 {
 	int type = gettagtype();
 	enum tag_result result;
@@ -217,8 +211,7 @@ tagsearch(VOID_PARAM)
  * Go to the next tag.
  */
 	public char *
-nexttag(n)
-	int n;
+nexttag(int n)
 {
 	char *tagfile = (char *) NULL;
 
@@ -231,8 +224,7 @@ nexttag(n)
  * Go to the previous tag.
  */
 	public char *
-prevtag(n)
-	int n;
+prevtag(int n)
 {
 	char *tagfile = (char *) NULL;
 
@@ -267,9 +259,8 @@ curr_tag(VOID_PARAM)
  * Find tags in the "tags" file.
  * Sets curtag to the first tag entry.
  */
-	static enum tag_result
-findctag(tag)
-	char *tag;
+	static enum tag_result 
+findctag(char *tag)
 {
 	char *p;
 	char *q;
@@ -395,10 +386,8 @@ edit_tagfile(VOID_PARAM)
 	return (edit(curtag->tag_file));
 }
 
-	static int
-curtag_match(line, linepos)
-	char constant *line;
-	POSITION linepos;
+	static int 
+curtag_match(char constant *line, POSITION linepos)
 {
 	/*
 	 * Test the line to see if we have a match.
@@ -505,10 +494,11 @@ ctagsearch(VOID_PARAM)
  * for future use by gtagsearch().
  * Sets curtag to the first tag entry.
  */
-	static enum tag_result
-findgtag(tag, type)
-	char *tag;              /* tag to load */
-	int type;               /* tags type */
+	static enum tag_result 
+findgtag (
+    char *tag,              /* tag to load */
+    int type               /* tags type */
+)
 {
 	char buf[1024];
 	FILE *fp;
@@ -736,12 +726,13 @@ gtagsearch(VOID_PARAM)
  * The tag, file, and line will each be NUL-terminated pointers
  * into buf.
  */
-	static int
-getentry(buf, tag, file, line)
-	char *buf;      /* standard or extended ctags -x format data */
-	char **tag;     /* name of the tag we actually found */
-	char **file;    /* file in which to find this tag */
-	char **line;    /* line number of file where this tag is found */
+	static int 
+getentry (
+    char *buf,      /* standard or extended ctags -x format data */
+    char **tag,     /* name of the tag we actually found */
+    char **file,    /* file in which to find this tag */
+    char **line    /* line number of file where this tag is found */
+)
 {
 	char *p = buf;
 

--- a/ttyin.c
+++ b/ttyin.c
@@ -36,9 +36,8 @@ extern int utf_mode;
 extern int wheel_lines;
 
 #if !MSDOS_COMPILER
-	static int
-open_tty_device(dev)
-	constant char* dev;
+	static int 
+open_tty_device(constant char *dev)
 {
 #if OS2
 	/* The __open() system call translates "/dev/tty" to "con". */
@@ -135,9 +134,8 @@ close_getchr(VOID_PARAM)
 /*
  * Close the pipe, restoring the keyboard (CMD resets it, losing the mouse).
  */
-	int
-pclose(f)
-	FILE *f;
+	int 
+pclose(FILE *f)
 {
 	int result;
 

--- a/xbuf.c
+++ b/xbuf.c
@@ -4,26 +4,23 @@
 /*
  * Initialize an expandable text buffer.
  */
-	public void
-xbuf_init(xbuf)
-	struct xbuffer *xbuf;
+	public void 
+xbuf_init(struct xbuffer *xbuf)
 {
 	xbuf->data = NULL;
 	xbuf->size = xbuf->end = 0;
 }
 
-	public void
-xbuf_deinit(xbuf)
-	struct xbuffer *xbuf;
+	public void 
+xbuf_deinit(struct xbuffer *xbuf)
 {
 	if (xbuf->data != NULL)
 		free(xbuf->data);
 	xbuf_init(xbuf);
 }
 
-	public void
-xbuf_reset(xbuf)
-	struct xbuffer *xbuf;
+	public void 
+xbuf_reset(struct xbuffer *xbuf)
 {
 	xbuf->end = 0;
 }
@@ -31,10 +28,8 @@ xbuf_reset(xbuf)
 /*
  * Add a byte to an expandable text buffer.
  */
-	public void
-xbuf_add_byte(xbuf, b)
-	struct xbuffer *xbuf;
-	unsigned int b;
+	public void 
+xbuf_add_byte(struct xbuffer *xbuf, unsigned int b)
 {
 	if (xbuf->end >= xbuf->size)
 	{
@@ -52,37 +47,30 @@ xbuf_add_byte(xbuf, b)
 }
 
 	public void 
-xbuf_add_data(xbuf, data, len)
-	struct xbuffer *xbuf;
-	unsigned char *data;
-	int len;
+xbuf_add_data(struct xbuffer *xbuf, unsigned char *data, int len)
 {
 	int i;
 	for (i = 0;  i < len;  i++)
 		xbuf_add_byte(xbuf, data[i]);
 }
 
-	public int
-xbuf_pop(buf)
-	struct xbuffer *buf;
+	public int 
+xbuf_pop(struct xbuffer *buf)
 {
 	if (buf->end == 0)
 		return -1;
 	return (int) buf->data[--(buf->end)];
 }
 
-	public void
-xbuf_set(dst, src)
-	struct xbuffer *dst;
-	struct xbuffer *src;
+	public void 
+xbuf_set(struct xbuffer *dst, struct xbuffer *src)
 {
 	xbuf_reset(dst);
 	xbuf_add_data(dst, src->data, src->end);
 }
 
 	public char *
-xbuf_char_data(xbuf)
-	struct xbuffer *xbuf;
+xbuf_char_data(struct xbuffer *xbuf)
 {
 	return (char *)(xbuf->data);
 }


### PR DESCRIPTION
Many of the function definitions in `less` are in the traditional (K&R) style. In this PR, I've updated them to the ANSI style. To do so, I used [`cproto`](https://invisible-island.net/cproto/cproto.html), fixed some complicated lines manually, and checked that nothing was missed by passing `-Werror=old-style-definition` to `gcc`. I also updated the function header generation scripts to expect the ANSI style. This would fix #316.