### PR TITLE
Port to Autoconf 2.71 (#320)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,13 +9,13 @@
 # contact the author, see the README file.
 
 # Autoconf initialization.
-AC_INIT(less, 1)
+AC_INIT([less],[1])
 AC_CONFIG_SRCDIR([forwback.c])
-AC_CONFIG_HEADER([defines.h])
+AC_CONFIG_HEADERS([defines.h])
 
 # Checks for programs.
 AC_PROG_CC
-AC_ISC_POSIX
+AC_SEARCH_LIBS([strerror], [cposix])
 AC_PROG_GCC_TRADITIONAL
 AC_PROG_INSTALL
 
@@ -36,7 +36,6 @@ AC_CHECK_LIB(termlib, tgetent, [have_termlib=yes], [have_termlib=no])
 AC_SEARCH_LIBS([regcmp], [gen intl PW])
 
 # Checks for header files.
-AC_HEADER_STDC
 AC_CHECK_HEADERS([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h wctype.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
@@ -44,7 +43,8 @@ AC_HEADER_STAT
 AC_C_CONST
 AC_TYPE_OFF_T
 AC_TYPE_SIZE_T
-AC_HEADER_TIME
+AC_CHECK_HEADERS_ONCE([sys/time.h])
+
 
 # Checks for terminal libraries
 AC_MSG_CHECKING([for working terminal libraries])
@@ -71,7 +71,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-ltinfo"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+	 [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -84,7 +87,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-ltinfow"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+	 [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -97,7 +103,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-lxcurses"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+	 [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -110,7 +119,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-lncursesw"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+         [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -123,7 +135,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-lncurses"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+	 [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -136,7 +151,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-lcurses"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+	 [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -150,7 +168,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-lcurses -ltermcap"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+	 [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -165,7 +186,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-ltermcap"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+	 [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -178,7 +202,10 @@ if test "x$TERMLIBS" = x; then
     TERMLIBS="-lcurses -ltermlib"
     SAVE_LIBS=$LIBS
     LIBS="$LIBS $TERMLIBS"
-    AC_TRY_LINK([$include_termcap_h], [tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);],
+    AC_LINK_IFELSE(
+      [AC_LANG_PROGRAM(
+	 [[$include_termcap_h]],
+	 [[tgetent(0,0); tgetflag(0); tgetnum(0); tgetstr(0,0);]])],
       [termok=yes], [termok=no])
     LIBS=$SAVE_LIBS
     if test $termok = no; then TERMLIBS=""; fi
@@ -257,70 +284,100 @@ AH_TEMPLATE([SECURE_COMPILE],
 # Checks for identifiers.
 AC_TYPE_OFF_T
 AC_MSG_CHECKING(for void)
-AC_TRY_COMPILE(, [void *foo = 0;], 
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[void *foo = 0;]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_VOID)], [AC_MSG_RESULT(no)])
 AC_MSG_CHECKING(for const)
-AC_TRY_COMPILE(, [const int foo = 0;], 
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[const int foo = 0;]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_CONST)], [AC_MSG_RESULT(no)])
 AC_MSG_CHECKING(for time_t)
-AC_TRY_COMPILE([#include <time.h>], [time_t t = 0;],
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
+#include <time.h>
+     ]],
+     [[time_t t = 0;]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_TIME_T)], [AC_MSG_RESULT(no)])
 AC_MSG_CHECKING(for st_ino in struct stat)
-AC_TRY_COMPILE([#include <sys/types.h>
-#include <sys/stat.h>],
-  [struct stat s; dev_t dev = s.st_dev; ino_t ino = s.st_ino;],
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
+#include <sys/types.h>
+#include <sys/stat.h>
+     ]],
+     [[struct stat s; dev_t dev = s.st_dev; ino_t ino = s.st_ino;]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_STAT_INO)], [AC_MSG_RESULT(no)])
 AC_MSG_CHECKING(for procfs)
-AC_TRY_COMPILE([#include <sys/statfs.h>
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
+#include <sys/statfs.h>
 #if HAVE_LINUX_MAGIC_H
 #include <linux/magic.h>
-#endif],
-  [struct statfs s; s.f_type = PROC_SUPER_MAGIC; (void) fstatfs(0,&s); ],
+#endif
+     ]],
+     [[struct statfs s; s.f_type = PROC_SUPER_MAGIC; (void) fstatfs(0,&s);]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_PROCFS)], [AC_MSG_RESULT(no)])
 
 # Checks for ANSI function prototypes.
 AC_MSG_CHECKING(for ANSI function prototypes)
-AC_TRY_COMPILE([], [int f(int a) { return a; }],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[int f(int a) { return a; }]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_ANSI_PROTOS)], [AC_MSG_RESULT(no)])
 
 # Checks for library functions.
-AC_TYPE_SIGNAL
 AC_CHECK_FUNCS([fchmod fsync nanosleep poll popen realpath _setjmp sigprocmask sigsetmask snprintf stat system ttyname usleep])
 
 # AC_CHECK_FUNCS may not work for inline functions, so test these separately.
 AC_MSG_CHECKING(for memcpy)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #if HAVE_STRING_H
 #include <string.h>
-#endif], [memcpy(0,0,0);],
+#endif
+     ]],
+     [[memcpy(0,0,0);]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_MEMCPY)], [AC_MSG_RESULT(no)])
 
 AC_MSG_CHECKING(for strchr)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #if HAVE_STRING_H
 #include <string.h>
-#endif], [strchr("x",'x');],
+#endif
+     ]],
+     [[strchr("x",'x');]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_STRCHR)], [AC_MSG_RESULT(no)])
 
 AC_MSG_CHECKING(for strstr)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #if HAVE_STRING_H
 #include <string.h>
-#endif], [strstr("x","x");],
+#endif
+     ]],
+     [[strstr("x","x");]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_STRSTR)], [AC_MSG_RESULT(no)])
 
 # Some systems have termios.h but not the corresponding functions.
 AC_CHECK_FUNC(tcgetattr, AC_DEFINE(HAVE_TERMIOS_FUNCS))
 
 AC_MSG_CHECKING(for fileno)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #if HAVE_STDIO_H
 #include <stdio.h>
-#endif], [static int x; x = fileno(stdin);],
+#endif
+     ]],
+     [[static int x; x = fileno(stdin);]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_FILENO)], [AC_MSG_RESULT(no)])
 
 AC_MSG_CHECKING(for strerror)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #if HAVE_STDIO_H
 #include <stdio.h>
 #endif
@@ -329,68 +386,105 @@ AC_TRY_LINK([
 #endif
 #if HAVE_ERRNO_H
 #include <errno.h>
-#endif], [static char *x; x = strerror(0);],
+#endif
+     ]],
+     [[static char *x; x = strerror(0);]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_STRERROR)], [AC_MSG_RESULT(no)])
 
 AC_MSG_CHECKING(for sys_errlist)
-AC_TRY_LINK(, [extern char *sys_errlist[]; static char **x; x = sys_errlist;], 
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[]],
+     [[extern char *sys_errlist[]; static char **x; x = sys_errlist;]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYS_ERRLIST)], [AC_MSG_RESULT(no)])
 
 AC_CHECK_TYPES([sigset_t],,,[#include <signal.h>])
 
 AC_MSG_CHECKING(for sigemptyset)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #include <signal.h>
-], [sigset_t s; sigemptyset(&s);],
+     ]],
+     [[sigset_t s; sigemptyset(&s);]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SIGEMPTYSET)], [AC_MSG_RESULT(no)])
 
 have_errno=no
 AC_MSG_CHECKING(for errno)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #if HAVE_ERRNO_H
 #include <errno.h>
-#endif], [static int x; x = errno;], 
+#endif
+     ]],
+     [[static int x; x = errno;]])],
   [AC_MSG_RESULT(yes - in errno.h); AC_DEFINE(HAVE_ERRNO) have_errno=yes])
 if test $have_errno = no; then
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #if HAVE_ERRNO_H
 #include <errno.h>
-#endif], [extern int errno; static int x; x = errno;], 
+#endif
+     ]],
+     [[extern int errno; static int x; x = errno;]])],
   [AC_MSG_RESULT(yes - must define); AC_DEFINE(HAVE_ERRNO) AC_DEFINE(MUST_DEFINE_ERRNO)],
   [AC_MSG_RESULT(no)])
 fi
 
 AC_MSG_CHECKING(for locale)
-AC_TRY_LINK([#include <locale.h>
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
+#include <locale.h>
 #include <ctype.h>
-#include <langinfo.h>], [setlocale(LC_CTYPE,""); isprint(0); iscntrl(0);],
+#include <langinfo.h>
+     ]],
+     [[setlocale(LC_CTYPE,""); isprint(0); iscntrl(0);]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_LOCALE)], [AC_MSG_RESULT(no)])
 
 AC_MSG_CHECKING(for ctype functions)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #if HAVE_CTYPE_H
 #include <ctype.h>
-#endif], [static int x; x = isupper(x); x = tolower(x); x = toupper(x);],
+#endif
+     ]],
+     [[static int x; x = isupper(x); x = tolower(x); x = toupper(x);]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_UPPER_LOWER)], [AC_MSG_RESULT(no)])
 
 AC_MSG_CHECKING(for wctype functions)
-AC_TRY_LINK([#include <wctype.h>], [iswlower(0); iswupper(0); towlower(0); towupper(0);],
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
+#include <wctype.h>
+     ]],
+     [[iswlower(0); iswupper(0); towlower(0); towupper(0);]])],
   [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_WCTYPE)], [AC_MSG_RESULT(no)])
 
 # Checks for external variable ospeed in the termcap library.
 have_ospeed=no
 AC_MSG_CHECKING(termcap for ospeed)
-AC_TRY_LINK([
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
 #include <sys/types.h>
 #if HAVE_TERMIOS_H
 #include <termios.h>
 #endif
 #if HAVE_TERMCAP_H
 #include <termcap.h>
-#endif], [ospeed = 0;],
-[AC_MSG_RESULT(yes - in termcap.h); AC_DEFINE(HAVE_OSPEED) have_ospeed=yes])
+#endif
+     ]],
+     [[ospeed = 0;]])],
+  [AC_MSG_RESULT(yes - in termcap.h); AC_DEFINE(HAVE_OSPEED) have_ospeed=yes])
 if test $have_ospeed = no; then
-AC_TRY_LINK(, [extern short ospeed; ospeed = 0;], 
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[]],
+     [[extern short ospeed; ospeed = 0;]])],
   [AC_MSG_RESULT(yes - must define); AC_DEFINE(HAVE_OSPEED) AC_DEFINE(MUST_DEFINE_OSPEED)],
   [AC_MSG_RESULT(no)])
 fi
@@ -408,7 +502,8 @@ AC_ARG_WITH(no-float,
   [  --with-no-float         Do not use floating point],
   WANT_NO_FLOAT=1, WANT_NO_FLOAT=0)
 if test $WANT_NO_FLOAT = 0; then
-  AC_TRY_LINK(, [double f1 = 12.5; double f2 = f1*f1/2.5;], 
+  AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([[]], [[double f1 = 12.5; double f2 = f1*f1/2.5;]])],
     [AC_MSG_RESULT(yes); AC_DEFINE(HAVE_FLOAT)], [AC_MSG_RESULT(no)])
 else
   AC_MSG_RESULT(disabled by user)
@@ -430,7 +525,8 @@ if test $WANT_REGEX = auto -o $WANT_REGEX = posix; then
 # Some versions of Solaris have a regcomp() function, but it doesn't work!
 # So we run a test program.  If we're cross-compiling, do it the old way.
 AC_MSG_CHECKING(for POSIX regcomp)
-AC_TRY_RUN([
+AC_RUN_IFELSE(
+  [AC_LANG_SOURCE([[
 #include <sys/types.h>
 #include <regex.h>
 int main() { regex_t r; regmatch_t rm; char *text = "xabcy";
@@ -441,19 +537,23 @@ if (rm.rm_so != 1) return (1); /* check for correct offset */
 #else
 if (rm.rm_sp != text + 1) return (1); /* check for correct offset */
 #endif
-return (0); }],
-  have_posix_regex=yes, have_posix_regex=no, have_posix_regex=unknown)
+return (0); }]])],
+  [have_posix_regex=yes], [have_posix_regex=no], [have_posix_regex=unknown])
 if test $have_posix_regex = yes; then
   AC_MSG_RESULT(yes)
   AC_DEFINE(HAVE_POSIX_REGCOMP) supported_regex="$supported_regex posix"
   have_regex=yes
 elif test $have_posix_regex = unknown; then
-  AC_TRY_LINK([
+  AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM(
+     [[
 #include <sys/types.h>
-#include <regex.h>],
-  [regex_t *r; regfree(r);],
-  AC_MSG_RESULT(yes)
-  AC_DEFINE(HAVE_POSIX_REGCOMP) have_regex=yes; supported_regex="$supported_regex posix")
+#include <regex.h>
+     ]],
+     [[regex_t *r; regfree(r);]])],
+    [AC_MSG_RESULT(yes)
+     AC_DEFINE(HAVE_POSIX_REGCOMP)
+     have_regex=yes; supported_regex="$supported_regex posix"])
 else
   AC_MSG_RESULT(no)
 fi
@@ -491,9 +591,16 @@ fi
 if test $have_regex = no; then
 if test $WANT_REGEX = auto -o $WANT_REGEX = regcomp; then
 AC_MSG_CHECKING(for V8 regcomp)
-AC_TRY_LINK([
-#include "regexp.h"], [regcomp("");],
-[AC_MSG_RESULT(yes); AC_DEFINE(HAVE_V8_REGCOMP) have_regex=yes; supported_regex="$supported_regex regcomp"],[AC_MSG_RESULT(no)])
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[
+#include "regexp.h"
+     ]],
+     [[regcomp("");]])],
+  [AC_MSG_RESULT(yes)
+   AC_DEFINE(HAVE_V8_REGCOMP)
+   have_regex=yes; supported_regex="$supported_regex regcomp"],
+  [AC_MSG_RESULT(no)])
 fi
 fi
 

--- a/defines.ds
+++ b/defines.ds
@@ -224,9 +224,6 @@
 /* Define if you need to in order for stat and other things to work.  */
 /* #undef _POSIX_SOURCE */
 
-/* Define as the return type of signal handlers (int or void).  */
-#define RETSIGTYPE void
-
 
 /*
  * Regular expression library.

--- a/defines.o2
+++ b/defines.o2
@@ -203,9 +203,6 @@
 /* Define if you need to in order for stat and other things to work.  */
 /* #undef _POSIX_SOURCE */
 
-/* Define as the return type of signal handlers (int or void).  */
-#define RETSIGTYPE void
-
 
 /*
  * Regular expression library.

--- a/defines.o9
+++ b/defines.o9
@@ -210,13 +210,6 @@
 /* Define if you need to in order for stat and other things to work.  */
 #define _POSIX_SOURCE 0
 
-/* Define as the return type of signal handlers (int or void).  */
-#if _OSK_MWC32
-#define RETSIGTYPE int
-#else
-#define RETSIGTYPE void
-#endif
-
 
 /*
  * Regular expression library.

--- a/defines.wn
+++ b/defines.wn
@@ -204,9 +204,6 @@
 /* Define if you need to in order for stat and other things to work.  */
 /* #undef _POSIX_SOURCE */
 
-/* Define as the return type of signal handlers (int or void).  */
-#define RETSIGTYPE void
-
 
 /*
  * Regular expression library.

--- a/os.c
+++ b/os.c
@@ -412,7 +412,7 @@ void * memcpy(void *dst, void *src, int len)
 /*
  * This implements an ANSI-style intercept setup for Microware C 3.2
  */
-public int os9_signal(int type, RETSIGTYPE (*handler)())
+public int os9_signal(int type, void (*handler)())
 {
 	intercept(handler);
 }

--- a/signal.c
+++ b/signal.c
@@ -41,7 +41,7 @@ extern long jump_sline_fraction;
  */
 #if MSDOS_COMPILER!=WIN32C
 	/* ARGSUSED*/
-static RETSIGTYPE u_interrupt(int type)
+static void u_interrupt(int type)
 {
 	bell();
 #if OS2
@@ -71,7 +71,7 @@ static RETSIGTYPE u_interrupt(int type)
  * "Stop" (^Z) signal handler.
  */
 	/* ARGSUSED*/
-static RETSIGTYPE stop(int type)
+static void stop(int type)
 {
 	LSIGNAL(SIGTSTP, stop);
 	sigs |= S_STOP;
@@ -94,7 +94,7 @@ static RETSIGTYPE stop(int type)
  * "Window" change handler
  */
 	/* ARGSUSED*/
-public RETSIGTYPE winch(int type)
+public void winch(int type)
 {
 	LSIGNAL(SIG_LESSWINDOW, winch);
 	sigs |= S_WINCH;
@@ -128,7 +128,7 @@ static BOOL WINAPI wbreak_handler(DWORD dwCtrlType)
 }
 #endif
 
-static RETSIGTYPE terminate(int type)
+static void terminate(int type)
 {
 	quit(15);
 }


### PR DESCRIPTION
This consisted of running 'autoupdate' and then minimally fixing up to keep the patch small and the build working. The manual fixes were mostly just to fix indenting. However, one nontrivial fix was to stop using RETSIGTYPE which Autoconf 2.63 (2008) declared permanently obsolete. The only platform that cares about this is the OS-9 version for Microware C 3.2, and I expect the code will still compile and run anyway (perhaps with a warning), in the unlikely case that an OS-9 user builds with Makefile.o9c instead of Makefile.o9g or Makefile.o9u.