### PR TITLE
Autoconf fixes2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@
 # Autoconf initialization.
 AC_INIT([less],[1])
 AC_CONFIG_SRCDIR([forwback.c])
-AC_CONFIG_HEADER([defines.h])
+AC_CONFIG_HEADERS([defines.h])
 
 # Checks for programs.
 AC_PROG_CC
@@ -36,15 +36,13 @@ AC_CHECK_LIB(termlib, tgetent, [have_termlib=yes], [have_termlib=no])
 AC_SEARCH_LIBS([regcmp], [gen intl PW])
 
 # Checks for header files.
-AC_HEADER_STDC
-AC_CHECK_HEADERS([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h wctype.h])
+AC_CHECK_HEADERS([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h sys/types.h time.h wctype.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STAT
 AC_C_CONST
 AC_TYPE_OFF_T
 AC_TYPE_SIZE_T
-AC_HEADER_TIME
 
 # Checks for terminal libraries
 AC_MSG_CHECKING([for working terminal libraries])

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ AC_CHECK_LIB(termlib, tgetent, [have_termlib=yes], [have_termlib=no])
 AC_SEARCH_LIBS([regcmp], [gen intl PW])
 
 # Checks for header files.
-AC_CHECK_HEADERS([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h sys/types.h time.h wctype.h])
+AC_CHECK_HEADERS_ONCE([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h sys/types.h time.h wctype.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STAT
@@ -244,7 +244,6 @@ AH_TEMPLATE([SECURE_COMPILE],
 	[Define SECURE_COMPILE=1 to build a secure version of less.])
 
 # Checks for identifiers.
-AC_TYPE_OFF_T
 AC_MSG_CHECKING(for void)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[void *foo = 0;]])],[AC_MSG_RESULT(yes); AC_DEFINE(HAVE_VOID)],[AC_MSG_RESULT(no)])
 AC_MSG_CHECKING(for const)


### PR DESCRIPTION
This is a followup to my earlier set of fixes for porting `less` better to Autoconf 2.71.

The first patch modifies `configure.ac` to stop using macros that Autoconf has declared obsolete. It assumes Autoconf 2.50 (2001) or later, which is quite safe nowadays.

The second patch is a minor cleanup, so that `configure` doesn't do the same check more than once. On my platform this shrinks the size of `configure` by 3221 bytes and makes `configure` a little faster and a bit less chatty.