### PR TITLE
Improve input preprocessor failure diagnostics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ AC_CHECK_LIB(termlib, tgetent, [have_termlib=yes], [have_termlib=no])
 AC_SEARCH_LIBS([regcmp], [gen intl PW])
 
 # Checks for header files.
-AC_CHECK_HEADERS_ONCE([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h sys/types.h time.h wctype.h])
+AC_CHECK_HEADERS_ONCE([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h sys/types.h sys/wait.h time.h wctype.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STAT
@@ -264,7 +264,7 @@ AC_MSG_CHECKING(for ANSI function prototypes)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[int f(int a) { return a; }]])],[AC_MSG_RESULT(yes); AC_DEFINE(HAVE_ANSI_PROTOS)],[AC_MSG_RESULT(no)])
 
 # Checks for library functions.
-AC_CHECK_FUNCS([fchmod fsync nanosleep poll popen realpath _setjmp sigprocmask sigsetmask snprintf stat system ttyname usleep])
+AC_CHECK_FUNCS([fchmod fsync nanosleep poll popen realpath _setjmp sigprocmask sigsetmask snprintf stat strsignal system ttyname usleep])
 
 # AC_CHECK_FUNCS may not work for inline functions, so test these separately.
 AC_MSG_CHECKING(for memcpy)

--- a/os.c
+++ b/os.c
@@ -338,6 +338,22 @@ public char * errno_message(char *filename)
 	return (m);
 }
 
+/*
+ * Return a description of a signal.
+ * The return value is good until the next call to this function.
+ */
+public char * signal_message(int sig)
+{
+	static char sigbuf[sizeof "signal " + INT_STRLEN_BOUND(sig)];
+#if HAVE_STRSIGNAL
+	char *description = strsignal(sig);
+	if (description)
+		return description;
+#endif
+	sprintf(sigbuf, "Signal %d", sig);
+	return sigbuf;
+}
+
 /* #define HAVE_FLOAT 0 */
 
 static POSITION muldiv(POSITION val, POSITION num, POSITION den)


### PR DESCRIPTION
This fixes gwsw/less issue #327.
* configure.ac: Check for sys/wait.h and for strsignal.
* edit.c: Include <sys/wait.h> if available.
(close_pipe): Always diagnose internal error with pclose. On POSIX-compatible systems, generate better diagnostics that distinguish between ordinary exit and signals, and do not diagnose SIGPIPE after the user types 'q' as that is normal and expected.
* os.c (signal_message): New function.