### PR TITLE
improved integer overflow fixes

### DIFF
--- a/ch.c
+++ b/ch.c
@@ -651,7 +651,8 @@ public void ch_setbufspace(int bufspace)
 		maxbufs = -1;
 	else
 	{
-		maxbufs = ((bufspace * 1024) + LBUFSIZE-1) / LBUFSIZE;
+		int lbufk = LBUFSIZE / 1024;
+		maxbufs = bufspace / lbufk + (bufspace % lbufk != 0);
 		if (maxbufs < 1)
 			maxbufs = 1;
 	}

--- a/charset.c
+++ b/charset.c
@@ -266,10 +266,12 @@ static void ichardef(char *s)
 
 		case '0': case '1': case '2': case '3': case '4':
 		case '5': case '6': case '7': case '8': case '9':
-			n = (10 * n) + (s[-1] - '0');
+			if (ckd_mul(&n, n, 10) || ckd_add(&n, n, s[-1] - '0'))
+				goto invalid_chardef;
 			continue;
 
 		default:
+		invalid_chardef:
 			error("invalid chardef", NULL_PARG);
 			quit(QUIT_ERROR);
 			/*NOTREACHED*/

--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -1291,13 +1291,11 @@ public LINENUM cmd_int(long *frac)
 
 	for (p = cmdbuf;  *p >= '0' && *p <= '9';  p++)
 	{
-		LINENUM nn = (n * 10) + (*p - '0');
-		if (nn < n)
+		if (ckd_mul(&n, n, 10) || ckd_add(&n, n, *p - '0'))
 		{
 			error("Integer is too big", NULL_PARG);
 			return (0);
 		}
-		n = nn;
 	}
 	*frac = 0;
 	if (*p++ == '.')

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ AC_CHECK_LIB(termlib, tgetent, [have_termlib=yes], [have_termlib=no])
 AC_SEARCH_LIBS([regcmp], [gen intl PW])
 
 # Checks for header files.
-AC_CHECK_HEADERS_ONCE([ctype.h errno.h fcntl.h limits.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h sys/types.h sys/wait.h time.h wctype.h])
+AC_CHECK_HEADERS_ONCE([ctype.h errno.h fcntl.h inttypes.h limits.h stdckdint.h stdio.h stdlib.h string.h termcap.h termio.h termios.h time.h unistd.h values.h linux/magic.h sys/ioctl.h sys/stream.h sys/types.h sys/wait.h time.h wctype.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STAT

--- a/configure.ac
+++ b/configure.ac
@@ -202,8 +202,6 @@ AH_TEMPLATE([HAVE_REGEXEC2],
 	[])
 AH_TEMPLATE([HAVE_VOID],
 	[Define HAVE_VOID if your compiler supports the "void" type.])
-AH_TEMPLATE([HAVE_FLOAT],
-	[Define HAVE_FLOAT if your compiler supports the "double" type.])
 AH_TEMPLATE([HAVE_CONST],
 	[Define HAVE_CONST if your compiler supports the "const" modifier.])
 AH_TEMPLATE([HAVE_STAT_INO],
@@ -364,17 +362,6 @@ AC_ARG_WITH(secure,
   AC_DEFINE(SECURE_COMPILE, 1)
   AC_SUBST(SECURE_COMPILE,1), AC_DEFINE(SECURE_COMPILE, 0)
   AC_SUBST(SECURE_COMPILE,0))
-
-# Should we use floating point?
-AC_MSG_CHECKING(for floating point)
-AC_ARG_WITH(no-float,
-  [  --with-no-float         Do not use floating point],
-  WANT_NO_FLOAT=1, WANT_NO_FLOAT=0)
-if test $WANT_NO_FLOAT = 0; then
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[double f1 = 12.5; double f2 = f1*f1/2.5;]])],[AC_MSG_RESULT(yes); AC_DEFINE(HAVE_FLOAT)],[AC_MSG_RESULT(no)])
-else
-  AC_MSG_RESULT(disabled by user)
-fi
 
 # Checks for regular expression functions.
 have_regex=no

--- a/decode.c
+++ b/decode.c
@@ -472,7 +472,8 @@ static int getcc_int(char *pterm)
 				return (-1);
 			return (num);
 		}
-		num = (10 * num) + (ch - '0');
+		if (ckd_mul(&num, num, 10) || ckd_add(&num, num, ch - '0'))
+			return -1;
 		++digits;
 	}
 }

--- a/defines.ds
+++ b/defines.ds
@@ -342,9 +342,6 @@
 /* Define if you have the <fcntl.h> header file.  */
 #define HAVE_FCNTL_H 1
 
-/* Define HAVE_FLOAT if your compiler supports the "double" type. */
-#define HAVE_FLOAT 1
-
 /* Define if you have the <limits.h> header file.  */
 #define HAVE_LIMITS_H 1
 

--- a/defines.wn
+++ b/defines.wn
@@ -327,9 +327,6 @@
 /* Define if you have the <fcntl.h> header file.  */
 #define HAVE_FCNTL_H 1
 
-/* Define HAVE_FLOAT if your compiler supports the "double" type. */
-#define HAVE_FLOAT 1
-
 /* Define if you have the <limits.h> header file.  */
 #define HAVE_LIMITS_H 1
 

--- a/less.h
+++ b/less.h
@@ -353,7 +353,10 @@ typedef short POLL_EVENTS;
 #define READ_INTR       (-2)
 #define READ_AGAIN      (-3)
 
-/* A fraction is represented by an int n; the fraction is n/NUM_FRAC_DENOM */
+/*
+ * A fraction is represented by a long n; the fraction is n/NUM_FRAC_DENOM.
+ * To avoid overflow problems, 0 <= n < NUM_FRAC_DENUM <= LONG_MAX/100.
+ */
 #define NUM_FRAC_DENOM                  1000000
 #define NUM_LOG_FRAC_DENOM              6
 

--- a/less.h
+++ b/less.h
@@ -70,11 +70,35 @@
 #if HAVE_LIMITS_H
 #include <limits.h>
 #endif
+#if HAVE_STDINT_H
+# include <stdint.h>
+#endif
 #if HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
 #if HAVE_STRING_H
 #include <string.h>
+#endif
+
+#if HAVE_STDCKDINT_H
+# include <stdckdint.h>
+#else
+/*
+ * These substitutes for C23 stdckdint macros do not set *R on overflow,
+ * and they assume A and B are nonnegative.  That is good enough for us.
+ */
+# define ckd_add(r, a, b) help_ckd_add(r, a, b, sizeof *(r), signed_expr(*(r)))
+# define ckd_mul(r, a, b) help_ckd_mul(r, a, b, sizeof *(r), signed_expr(*(r)))
+/* True if the integer expression E, after promotion, is signed.  */
+# define signed_expr(e) ((TRUE ? 0 : e) - 1 < 0)
+#endif
+
+#if defined UINTMAX_MAX
+typedef uintmax_t uintmax;
+#elif defined ULLONG_MAX
+typedef unsigned long long uintmax;
+#else
+typedef unsigned long uintmax;
 #endif
 
 /* OS-specific includes */

--- a/lesskey.c
+++ b/lesskey.c
@@ -124,6 +124,12 @@ int lstrtoi(char *buf, char **ebuf, int radix)
 	return (int) strtol(buf, ebuf, radix);
 }
 
+void out_of_memory(void)
+{
+	fprintf(stderr, "lesskey: cannot allocate memory\n");
+	exit(1);
+}
+
 void * ecalloc(int count, unsigned int size)
 {
 	void *p;
@@ -131,8 +137,7 @@ void * ecalloc(int count, unsigned int size)
 	p = calloc(count, size);
 	if (p != NULL)
 		return (p);
-	fprintf(stderr, "lesskey: cannot allocate %d bytes of memory\n", count*size);
-	exit(1);
+	out_of_memory();
 }
 
 static char * mkpathname(char *dirname, char *filename)

--- a/main.c
+++ b/main.c
@@ -319,6 +319,12 @@ public char * save(constant char *s)
 	return (p);
 }
 
+public void out_of_memory(void)
+{
+	error("Cannot allocate memory", NULL_PARG);
+	quit(QUIT_ERROR);
+}
+
 /*
  * Allocate memory.
  * Like calloc(), but never returns an error (NULL).
@@ -328,12 +334,9 @@ public void * ecalloc(int count, unsigned int size)
 	void * p;
 
 	p = (void *) calloc(count, size);
-	if (p != NULL)
-		return (p);
-	error("Cannot allocate memory", NULL_PARG);
-	quit(QUIT_ERROR);
-	/*NOTREACHED*/
-	return (NULL);
+	if (!p)
+		out_of_memory();
+	return p;
 }
 
 /*

--- a/mark.c
+++ b/mark.c
@@ -409,12 +409,16 @@ public void restore_mark(char *line)
 		return;
 	skip_whitespace;
 	ln = lstrtoi(line, &line, 10);
+	if (ln < 0)
+		return;
 	if (ln < 1)
 		ln = 1;
 	if (ln > sc_height)
 		ln = sc_height;
 	skip_whitespace;
 	pos = lstrtopos(line, &line, 10);
+	if (pos < 0)
+		return;
 	skip_whitespace;
 	cmark(m, NULL_IFILE, pos, ln);
 	m->m_filename = save(line);

--- a/optfunc.c
+++ b/optfunc.c
@@ -213,7 +213,7 @@ public void calc_jump_sline(void)
 {
 	if (jump_sline_fraction < 0)
 		return;
-	jump_sline = sc_height * jump_sline_fraction / NUM_FRAC_DENOM;
+	jump_sline = muldiv(sc_height, jump_sline_fraction, NUM_FRAC_DENOM);
 }
 
 /*
@@ -273,7 +273,7 @@ public void calc_shift_count(void)
 {
 	if (shift_count_fraction < 0)
 		return;
-	shift_count = sc_width * shift_count_fraction / NUM_FRAC_DENOM;
+	shift_count = muldiv(sc_width, shift_count_fraction, NUM_FRAC_DENOM);
 }
 
 #if USERFILE

--- a/optfunc.c
+++ b/optfunc.c
@@ -680,10 +680,13 @@ public void set_tabs(char *s, int len)
 	/* Start at 1 because tabstops[0] is always zero. */
 	for (i = 1;  i < TABSTOP_MAX;  )
 	{
-		int n = 0;
-		while (s < es && *s >= '0' && *s <= '9')
-			n = (10 * n) + (*s++ - '0');
-		if (n > tabstops[i-1])
+		int n = 0, v = FALSE;
+		for (; s < es && *s >= '0' && *s <= '9'; s++)
+		{
+			v |= ckd_mul(&n, n, 10);
+			v |= ckd_add(&n, n, *s - '0');
+		}
+		if (!v && n > tabstops[i-1])
 			tabstops[i++] = n;
 		while (s < es && *s == ' ')
 			s++;

--- a/os.c
+++ b/os.c
@@ -354,8 +354,6 @@ public char * signal_message(int sig)
 	return sigbuf;
 }
 
-/* #define HAVE_FLOAT 0 */
-
 /*
  * Return (VAL * NUM) / DEN, where DEN is positive
  * and min(VAL, NUM) <= DEN so the result cannot overflow.

--- a/os.c
+++ b/os.c
@@ -460,7 +460,7 @@ public void sleep_ms(int ms)
 #if HAVE_USLEEP
 	usleep(ms);
 #else
-	sleep((ms+999) / 1000);
+	sleep(ms / 1000 + (ms % 1000 != 0));
 #endif
 #endif
 #endif

--- a/output.c
+++ b/output.c
@@ -490,20 +490,22 @@ TYPE_TO_A_FUNC(linenumtoa, LINENUM)
 TYPE_TO_A_FUNC(inttoa, int)
 
 /*
- * Convert an string to an integral type.
+ * Convert a string to an integral type.  Return ((type) -1) on overflow.
  */
 #define STR_TO_TYPE_FUNC(funcname, type) \
 type funcname(char *buf, char **ebuf, int radix) \
 { \
 	type val = 0; \
+	int v = 0; \
 	for (;; buf++) { \
 		char c = *buf; \
 		int digit = (c >= '0' && c <= '9') ? c - '0' : (c >= 'a' && c <= 'f') ? c - 'a' + 10 : (c >= 'A' && c <= 'F') ? c - 'A' + 10 : -1; \
 		if (digit < 0 || digit >= radix) break; \
-		val = radix * val + digit; \
+		v |= ckd_mul(&val, val, radix); \
+		v |= ckd_add(&val, val, digit); \
 	} \
 	if (ebuf != NULL) *ebuf = buf; \
-	return val; \
+	return v ? -1 : val; \
 }
 
 STR_TO_TYPE_FUNC(lstrtopos, POSITION)

--- a/screen.c
+++ b/screen.c
@@ -1665,7 +1665,8 @@ static void ltputs(char *str, int affcnt, int (*f_putc)(int))
 				/* Perform the delay. */
 				delay = lstrtoi(str, &str, 10);
 				if (*str == '*')
-					delay *= affcnt;
+					if (ckd_mul(&delay, delay, affcnt))
+						delay = INT_MAX;
 				flush();
 				sleep_ms(delay);
 				/* Skip past closing ">" at end of delay string. */
@@ -2461,7 +2462,7 @@ static int parse_color6(char **ps)
 	{
 		char *ops = *ps;
 		int color = lstrtoi(ops, ps, 10);
-		if (*ps == ops)
+		if (color < 0 || *ps == ops)
 			return CV_ERROR;
 		return color;
 	}

--- a/xbuf.c
+++ b/xbuf.c
@@ -30,7 +30,8 @@ public void xbuf_add_byte(struct xbuffer *xbuf, unsigned char b)
 	if (xbuf->end >= xbuf->size)
 	{
 		unsigned char *data;
-		xbuf->size = (xbuf->size == 0) ? 16 : xbuf->size * 2;
+		if (ckd_add(&xbuf->size, xbuf->size, xbuf->size ? xbuf->size : 16))
+			out_of_memory();
 		data = (unsigned char *) ecalloc(xbuf->size, sizeof(unsigned char));
 		if (xbuf->data != NULL)
 		{
@@ -66,3 +67,97 @@ public char * xbuf_char_data(struct xbuffer *xbuf)
 {
 	return (char *)(xbuf->data);
 }
+
+
+/*
+ * Helper functions for the ckd_add and ckd_mul macro substitutes.
+ * These helper functions do not set *R on overflow, and assume that
+ * arguments are nonnegative, that INTMAX_MAX <= UINTMAX_MAX, and that
+ * sizeof is a reliable way to distinguish integer representations.
+ * Despite these limitations they are good enough for 'less' on all
+ * known practical platforms.  For more-complicated substitutes
+ * without most of these limitations, see Gnulib's stdckdint module.
+ */
+#if !HAVE_STDCKDINT_H
+/*
+ * If the integer *R can represent VAL, store the value and return FALSE.
+ * Otherwise, possibly set *R to an indeterminate value and return TRUE.
+ * R has size RSIZE, and is signed if and only if RSIGNED is nonzero.
+ */
+static int help_fixup(void *r, uintmax val, int rsize, int rsigned)
+{
+	if (rsigned)
+	{
+		if (rsize == sizeof (int))
+		{
+			if (INT_MAX < val)
+				return TRUE;
+			int *pr = r;
+			*pr = val;
+# ifdef LLONG_MAX
+		} else if (rsize == sizeof (long long))
+		{
+			if (LLONG_MAX < val)
+				return TRUE;
+			long long *pr = r;
+			*pr = val;
+# endif
+# ifdef INTMAX_MAX
+		} else if (rsize == sizeof (intmax_t)) {
+			if (INTMAX_MAX < val)
+				return TRUE;
+			intmax_t *pr = r;
+			*pr = val;
+# endif
+		} else /* rsize == sizeof (long) */
+		{
+			if (LONG_MAX < val)
+				return TRUE;
+			long *pr = r;
+			*pr = val;
+		}
+	} else {
+		if (rsize == sizeof (unsigned)) {
+			if (UINT_MAX < val)
+				return TRUE;
+			unsigned *pr = r;
+			*pr = val;
+		} else if (rsize == sizeof (unsigned long)) {
+			if (ULONG_MAX < val)
+				return TRUE;
+			unsigned long *pr = r;
+			*pr = val;
+# ifdef ULLONG_MAX
+		} else if (rsize == sizeof (unsigned long long)) {
+			if (ULLONG_MAX < val)
+				return TRUE;
+			long long *pr = r;
+			*pr = val;
+# endif
+		} else /* rsize == sizeof (uintmax) */
+		{
+			uintmax *pr = r;
+			*pr = val;
+		}
+	}
+	return FALSE;
+}
+/*
+ * If *R can represent the mathematical sum of A and B, store the sum
+ * and return FALSE.  Otherwise, possibly set *R to an indeterminate
+ * value and return TRUE.  R has size RSIZE, and is signed if and only
+ * if RSIGNED is nonzero.
+ */
+public int help_ckd_add(void *r, uintmax a, uintmax b, int rsize, int rsigned)
+{
+	uintmax sum = a + b;
+	return sum < a || help_fixup(r, sum, rsize, rsigned);
+}
+/* Likewise, but for the product of A and B.  */
+public int help_ckd_mul(void *r, uintmax a, uintmax b, int rsize, int rsigned)
+{
+	uintmax product = a * b;
+	return ((b != 0 && a != product / b)
+		|| help_fixup(r, product, rsize, rsigned));
+}
+#endif


### PR DESCRIPTION
I looked at PR #243 and was inspired to write this new pull request, which does a better job of integer overflow detection. This PR does not fix all the integer overflow issues in `less` but I hope it catches most of the likely ones. This PR uses the following ideas:

1. When checking for integer overflow, use the `ckd_add` and `ckd_mul`macros that will be standardized in C23's `<stdckdint.h>`, and fall back on portable substitutes good enough for `less` on platforms that don't yet support these macros (which is most platforms today). This is because in the long run it'll be better to use the standard way of checking for integer overflow than to use idiosyncratic macros or functions.
2. Check for integer overflow in several places that the current code does not check.
3. Redo some integer calculations so that they can't overflow.
4. Avoid all use of `double`, so that `HAVE_FLOAT` is no longer needed.
5. Fix some minor rounding errors.

I think this PR does everything that PR #243 does, so if you install it you shouldn't need to install PR #243.