### PR TITLE
match: avoid segmentation fault with no_regex

### DIFF
--- a/pattern.c
+++ b/pattern.c
@@ -258,7 +258,7 @@ public int is_null_pattern(PATTERN_TYPE pattern)
  * Simple pattern matching function.
  * It supports no metacharacters like *, etc.
  */
-static int match(char *pattern, int pattern_len, char *buf, int buf_len, char **sp, char **ep, int nsubs)
+static int match(char *pattern, int pattern_len, char *buf, int buf_len, char ***sp, char ***ep, int nsubs)
 {
 	char *pp, *lp;
 	char *pattern_end = pattern + pattern_len;
@@ -279,12 +279,12 @@ static int match(char *pattern, int pattern_len, char *buf, int buf_len, char **
 		}
 		if (pp == pattern_end)
 		{
-			*sp++ = buf;
-			*ep++ = lp;
+			*(*sp)++ = buf;
+			*(*ep)++ = lp;
 			return (1);
 		}
 	}
-	*sp = *ep = NULL;
+	**sp = **ep = NULL;
 	return (0);
 }
 
@@ -302,7 +302,7 @@ public int match_pattern(PATTERN_TYPE pattern, char *tpattern, char *line, int l
 	search_type |= SRCH_NO_REGEX;
 #endif
 	if (search_type & SRCH_NO_REGEX)
-		matched = match(tpattern, strlen(tpattern), line, line_len, sp, ep, nsp);
+		matched = match(tpattern, strlen(tpattern), line, line_len, &sp, &ep, nsp);
 	else
 	{
 #if HAVE_GNU_REGEX


### PR DESCRIPTION
In f398927 (Use different colors for subpattern matches., 2023-01-09), `match_pattern()` was changed so that the `sp` and `ep` pointers no longer refer to a single start/end but to an array.

Unfortunately, the `match()` function that is used in the no-regex case was not adjusted correctly. While it _does_ advance `sp` and `ep` to the next array elements in case of a match, that advancement is only visible to the `match()` function, but not to its caller, `match_pattern()`, which subsequently assigns `*sp = *ep = NULL`, overwriting the values that were assigned by the  `match()` function.

As a consequence, the invariant where `search_range()` expects the `sp`/`ep` values to be non-`NULL` if `match_pattern()` returns non-zero is violated, and the `hilite_line()` function will call `create_hilites()` with those invalid values and subsequently access memory at an insanely large `start_index`, and crash.

Fix this by changing the `match()` function in a way where the `sp`/`ep` modifications are visible to its caller.