### PR TITLE
Fix deprecated prototype declarations

### DIFF
--- a/screen.c
+++ b/screen.c
@@ -296,9 +296,6 @@ extern DWORD console_mode;
 extern int tty;
 #endif
 
-extern char *tgetstr();
-extern char *tgoto();
-
 #if (HAVE_TERMIOS_H && HAVE_TERMIOS_FUNCS) || defined(TCGETA)
 /*
  * Set termio flags for use by less.

--- a/xbuf.h
+++ b/xbuf.h
@@ -14,6 +14,6 @@ void xbuf_reset(struct xbuffer *xbuf);
 void xbuf_add_byte(struct xbuffer *xbuf, unsigned char b);
 void xbuf_add_data(struct xbuffer *xbuf, unsigned char *data, int len);
 int xbuf_pop(struct xbuffer *xbuf);
-char *xbuf_char_data();
-	
+char *xbuf_char_data(struct xbuffer *xbuf);
+
 #endif


### PR DESCRIPTION
Fix the following set of compile time errors with Clang 16.

```
./xbuf.h:17:7: error: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent declaration [-Werror,-Wdeprecated-non-prototype]
char *xbuf_char_data();
      ^
./funcs.h:382:15: note: conflicting prototype is here
public char * xbuf_char_data(struct xbuffer *xbuf);
              ^
```

```
screen.c:299:14: error: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a previous declaration [-Werror,-Wdeprecated-non-prototype]
extern char *tgetstr();
             ^
/usr/include/termcap.h:61:31: note: conflicting prototype is here
extern NCURSES_EXPORT(char *) tgetstr (const char *, char **);
                              ^
screen.c:300:14: error: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a previous declaration [-Werror,-Wdeprecated-non-prototype]
extern char *tgoto();
             ^
/usr/include/termcap.h:62:31: note: conflicting prototype is here
extern NCURSES_EXPORT(char *) tgoto (const char *, int, int);
                              ^
```