### PR TITLE
Windows: fix iread

### DIFF
--- a/os.c
+++ b/os.c
@@ -244,11 +244,18 @@ start:
 	}
 #else
 #if MSDOS_COMPILER==WIN32C
-	if (win32_kbhit() && WIN32getch() == intr_char)
+	if (win32_kbhit())
 	{
-		sigs |= S_INTERRUPT;
-		reading = 0;
-		return (READ_INTR);
+		int c;
+
+		c = WIN32getch();
+		if (c == intr_char)
+		{
+			sigs |= S_INTERRUPT;
+			reading = 0;
+			return (READ_INTR);
+		}
+		WIN32ungetch(c);
 	}
 #endif
 #endif

--- a/screen.c
+++ b/screen.c
@@ -2956,6 +2956,16 @@ public char WIN32getch(void)
 
 	return ascii;
 }
+
+/*
+ * Restore the character read during iread.
+ */
+public void WIN32ungetch(int ch)
+{
+	currentKey.unicode = ch;
+	++keyCount;
+	pending_scancode = 0;
+}
 #endif
 
 #if MSDOS_COMPILER


### PR DESCRIPTION
The Windows version of iread removed the character, causing an extended sequence to be incorrectly split.  Add an unget function to put the character back.  Resolves #378.