### PR TITLE
mouse: bind right-click as jump-to-"#"-mark

### DIFF
--- a/less.nro.VER
+++ b/less.nro.VER
@@ -1267,8 +1267,8 @@ See the \-\-tabs description for acceptable values of \fIn\fP.
 Enables mouse input:
 scrolling the mouse wheel down moves forward in the file,
 scrolling the mouse wheel up moves backwards in the file,
-and clicking the mouse sets the "#" mark to the line
-where the mouse is clicked.
+left-click sets the "#" mark to the line where the mouse is clicked,
+and right-click (or any other) returns to the "#" mark position.
 The number of lines to scroll when the wheel is moved
 can be set by the \-\-wheel-lines option.
 Mouse input works only on terminals which support X11 mouse reporting,

--- a/screen.c
+++ b/screen.c
@@ -2861,14 +2861,19 @@ static int win32_mouse_event(XINPUT_RECORD *xip)
 		return (FALSE);
 
 	/* Generate an X11 mouse sequence from the mouse event. */
+	/* TODO: switch to the 1006 protocol to allow specific-button-up reports */
 	switch (xip->ir.Event.MouseEvent.dwEventFlags)
 	{
 	case 0: /* press or release */
 		if (xip->ir.Event.MouseEvent.dwButtonState == 0)
 			b = X11MOUSE_OFFSET + X11MOUSE_BUTTON_REL;
-		else if (!(xip->ir.Event.MouseEvent.dwButtonState & (FROM_LEFT_3RD_BUTTON_PRESSED | FROM_LEFT_4TH_BUTTON_PRESSED)))
-			b = X11MOUSE_OFFSET + X11MOUSE_BUTTON1 + ((int)xip->ir.Event.MouseEvent.dwButtonState << 1);
-		else
+		else if (xip->ir.Event.MouseEvent.dwButtonState == 1)  /* leftmost */
+			b = X11MOUSE_OFFSET + X11MOUSE_BUTTON1;
+		else if (xip->ir.Event.MouseEvent.dwButtonState == 2)  /* rightmost */
+			b = X11MOUSE_OFFSET + X11MOUSE_BUTTON3;
+		else if (xip->ir.Event.MouseEvent.dwButtonState == 4)  /* middle ("next-to-leftmost") */
+			b = X11MOUSE_OFFSET + X11MOUSE_BUTTON2;
+		else  /* don't bother to figure out what changed */
 			return (FALSE);
 		break;
 	case MOUSE_WHEELED:


### PR DESCRIPTION
Previously any mouse-button click set the "#" mark.

With this PR, left-click sets the "#" mark, and right-click jumps to the "#" mark.

There are two commits: the first fixes mouse-button-down encoding on windows in preparation, and the second adds the right-click binding as jump-to-mark.