### PR TITLE
Allow user to give CFLAGS and LDFLAGS when compiling lesstest

### DIFF
--- a/lesstest/Makefile
+++ b/lesstest/Makefile
@@ -1,5 +1,5 @@
 CC ?= gcc
-CFLAGS = -Wall -O2
+CFLAGS ?= -Wall -O2
 TERMLIB = -lncurses
 
 all: lesstest lt_screen 

--- a/lesstest/Makefile
+++ b/lesstest/Makefile
@@ -1,16 +1,17 @@
 CC ?= gcc
 CFLAGS ?= -Wall -O2
+LDFLAGS ?=
 TERMLIB = -lncurses
 
 all: lesstest lt_screen 
 
 LESSTEST_OBJ = display.o env.o lesstest.o parse.o pipeline.o log.o run.o term.o wchar.o
 lesstest: $(LESSTEST_OBJ)
-	$(CC) $(CFLAGS) -o lesstest $(LESSTEST_OBJ) $(TERMLIB)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o lesstest $(LESSTEST_OBJ) $(TERMLIB)
 
 LT_SCREEN_OBJ = lt_screen.o unicode.o wchar.o
 lt_screen: $(LT_SCREEN_OBJ)
-	$(CC) $(CFLAGS) -o lt_screen $(LT_SCREEN_OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o lt_screen $(LT_SCREEN_OBJ)
 
 *.o: lesstest.h lt_types.h wchar.h
 


### PR DESCRIPTION
Hi,
This pull request modify the `lesstest/Makefile` to allow user to give `CFLAGS` and `LDFLAGS` when compiling `lesstest`. 

I mainly need these changes for the Yocto integration: `CFLAGS` and `LDFLAGS` are given as environment variables and we need them to pass QA.

No functional changes are expected here for default case. 
 