### PR TITLE
lesstest: use pkg-config to find ncurses libraries

### DIFF
--- a/lesstest/Makefile
+++ b/lesstest/Makefile
@@ -1,7 +1,8 @@
 CC ?= gcc
 CFLAGS ?= -Wall -O2
 LDFLAGS ?=
-TERMLIB = -lncurses
+PKG_CONFIG ?= pkg-config
+TERMLIB ?= $(shell ${PKG_CONFIG} --libs ncurses)
 srcdir ?= .
 
 all: lesstest lt_screen 


### PR DESCRIPTION
Fails to build with split tinfo otherwise like:
```

x86_64-pc-linux-gnu-gcc -O2 -pipe -march=native -fdiagnostics-color=always -frecord-gcc-switches -Wreturn-type      -ggdb3 -Wl,-O1 -Wl,--as-needed -Wl,--defsym=__gentoo_check_ldflags__=0 -Wl,-z,pack-relative-relocs    -ggdb3 -o lesstest display.o env.o lesstest.o parse.o pipeline.o log.o run.o term.o wchar.o -lncurses
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: display.o: in function `display_screen':
/var/tmp/portage/sys-apps/less-643/work/less-643/lesstest/display.c:86:(.text+0x2e0): undefined reference to `tgoto'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: term.o: in function `setup_mode':
/var/tmp/portage/sys-apps/less-643/work/less-643/lesstest/term.c:83:(.text+0x18): undefined reference to `tgetstr'
[...]
```

Going forward, we may want to just add a Makefile.in which configure handles to the lesstest subdir.