### PR TITLE
Fix freebsd build (or unix in general)

### DIFF
--- a/edit.c
+++ b/edit.c
@@ -16,7 +16,7 @@
 #if HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif
-#if OS2
+#if OS2 || unix
 #include <signal.h>
 #endif
 


### PR DESCRIPTION
Needs <signal.h> for SIGPIPE.