### PR TITLE
win32: Fix to handle files larger than 4 GiB

### DIFF
--- a/ch.c
+++ b/ch.c
@@ -241,7 +241,7 @@ static int ch_get(void)
 			 */
 			if (!(ch_flags & CH_CANSEEK))
 				return ('?');
-			if (lseek(ch_file, (off_t)pos, SEEK_SET) == BAD_LSEEK)
+			if (less_lseek(ch_file, (less_off_t)pos, SEEK_SET) == BAD_LSEEK)
 			{
 				error("seek error", NULL_PARG);
 				clear_eol();
@@ -723,7 +723,7 @@ public void ch_flush(void)
 	}
 #endif
 
-	if (lseek(ch_file, (off_t)0, SEEK_SET) == BAD_LSEEK)
+	if (less_lseek(ch_file, (less_off_t)0, SEEK_SET) == BAD_LSEEK)
 	{
 		/*
 		 * Warning only; even if the seek fails for some reason,
@@ -806,7 +806,7 @@ public int seekable(int f)
 		return (0);
 	}
 #endif
-	return (lseek(f, (off_t)1, SEEK_SET) != BAD_LSEEK);
+	return (less_lseek(f, (less_off_t)1, SEEK_SET) != BAD_LSEEK);
 }
 
 /*

--- a/decode.c
+++ b/decode.c
@@ -820,7 +820,7 @@ public int lesskey(char *filename, int sysvar)
 		close(f);
 		return (-1);
 	}
-	if (lseek(f, (off_t)0, SEEK_SET) == BAD_LSEEK)
+	if (less_lseek(f, (less_off_t)0, SEEK_SET) == BAD_LSEEK)
 	{
 		free(buf);
 		close(f);

--- a/edit.c
+++ b/edit.c
@@ -984,7 +984,7 @@ loop:
 		 * Append: open the file and seek to the end.
 		 */
 		logfile = open(filename, OPEN_APPEND);
-		if (lseek(logfile, (off_t)0, SEEK_END) == BAD_LSEEK)
+		if (less_lseek(logfile, (less_off_t)0, SEEK_END) == BAD_LSEEK)
 		{
 			close(logfile);
 			logfile = -1;

--- a/filename.c
+++ b/filename.c
@@ -453,7 +453,7 @@ public int bin_file(int f)
 
 	if (!seekable(f))
 		return (0);
-	if (lseek(f, (off_t)0, SEEK_SET) == BAD_LSEEK)
+	if (less_lseek(f, (less_off_t)0, SEEK_SET) == BAD_LSEEK)
 		return (0);
 	n = read(f, data, sizeof(data));
 	if (n <= 0)
@@ -489,9 +489,9 @@ public int bin_file(int f)
  */
 static POSITION seek_filesize(int f)
 {
-	off_t spos;
+	less_off_t spos;
 
-	spos = lseek(f, (off_t)0, SEEK_END);
+	spos = less_lseek(f, (less_off_t)0, SEEK_END);
 	if (spos == BAD_LSEEK)
 		return (NULL_POSITION);
 	return ((POSITION) spos);
@@ -989,9 +989,9 @@ public int is_dir(char *filename)
 #if HAVE_STAT
 {
 	int r;
-	struct stat statbuf;
+	less_stat_t statbuf;
 
-	r = stat(filename, &statbuf);
+	r = less_stat(filename, &statbuf);
 	isdir = (r >= 0 && S_ISDIR(statbuf.st_mode));
 }
 #else
@@ -1030,9 +1030,9 @@ public char * bad_file(char *filename)
 	{
 #if HAVE_STAT
 		int r;
-		struct stat statbuf;
+		less_stat_t statbuf;
 
-		r = stat(filename, &statbuf);
+		r = less_stat(filename, &statbuf);
 		if (r < 0)
 		{
 			m = errno_message(filename);
@@ -1059,9 +1059,9 @@ public char * bad_file(char *filename)
 public POSITION filesize(int f)
 {
 #if HAVE_STAT
-	struct stat statbuf;
+	less_stat_t statbuf;
 
-	if (fstat(f, &statbuf) >= 0)
+	if (less_fstat(f, &statbuf) >= 0)
 		return ((POSITION) statbuf.st_size);
 #else
 #ifdef _OSK

--- a/less.h
+++ b/less.h
@@ -236,7 +236,20 @@ void free();
  * Special types and constants.
  */
 typedef unsigned long LWCHAR;
-typedef off_t           POSITION;
+#if defined(_MSC_VER) && _MSC_VER >= 1500
+typedef _int64 less_off_t;
+typedef struct _stat64 less_stat_t;
+#define less_fstat _fstat64
+#define less_stat _stat64
+#define less_lseek _lseeki64
+#else
+typedef off_t less_off_t;
+typedef struct stat less_stat_t;
+#define less_fstat fstat
+#define less_stat stat
+#define less_lseek lseek
+#endif
+typedef less_off_t      POSITION;
 typedef off_t           LINENUM;
 #define MIN_LINENUM_WIDTH   7   /* Default min printing width of a line number */
 #define MAX_LINENUM_WIDTH   16  /* Max width of a line number */


### PR DESCRIPTION
Need VS2008 or later.
Redefine `POSITION` to be 64-bit.
Then effectively redirect `stat()` and `lseek()` calls to their corresponding 64-bit filesize capable calls, `_stat64()` and `_lseeki64()` respectively.
Define and use `less_stat_t` as the required 64-bit filesize capable stat buffer.
Define and use `less_off_t` as 64-bit filesize.