### PR TITLE
lesskey.nro.VER: Fix render on mandoc/freebsd

### DIFF
--- a/lesskey.nro.VER
+++ b/lesskey.nro.VER
@@ -217,7 +217,7 @@ N	reverse-search
 m	set-mark
 M	set-mark-bottom
 \eem	clear-mark
-'	goto-mark
+\&'	goto-mark
 ^X^X	goto-mark
 E	examine
 :e	examine


### PR DESCRIPTION
Prepend a zero width space to ' on line 220.

Zero width space tells the roff processor that the apostrophe is not the call of an unsupported macro called goto-mark.

This fixes execution on mandoc/freebsd which formerly crashes with exit status 4. https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=268568