### PR TITLE
windows: mingw: support files bigger than 2G

### DIFF
--- a/less.h
+++ b/less.h
@@ -236,8 +236,8 @@ void free();
  * Special types and constants.
  */
 typedef unsigned long LWCHAR;
-#if defined(_MSC_VER) && _MSC_VER >= 1500
-typedef _int64 less_off_t;
+#if defined(MINGW) || (defined(_MSC_VER) && _MSC_VER >= 1500)
+typedef long long less_off_t;  /* __int64 */
 typedef struct _stat64 less_stat_t;
 #define less_fstat _fstat64
 #define less_stat _stat64


### PR DESCRIPTION
The changes of commit 44d5c6bb can also work for mingw, so enable it.

The type _int64 is not identified in mingw without further includes, so use long long instead (which is synonymous to __int64 according to MS docs)

Tested 32 and 64 bit mingw builds, with the 32 bits confirmed to open and seek to the end of a 7G file (where previously it didn't), and also tested and works on XP (tested only small files on XP).