### PR TITLE
windows: mingw: Makefile.wng: allow incremental build

### DIFF
--- a/Makefile.wng
+++ b/Makefile.wng
@@ -72,10 +72,12 @@ ifeq  (${SHELL},cmd.exe)
     CP = copy
     MV = move
     RM = del
+    DIFF = comp /M
 else
     CP = cp
     MV = mv
     RM = rm
+    DIFF = diff
 endif
 
 CFLAGS  = -O2 ${CFLAGS_MINGW}
@@ -116,23 +118,26 @@ OBJ += regexp.o
 endif
 
 
-all: clean less lesskey lessecho
+all: less.exe lesskey.exe lessecho.exe
 
-less: ${OBJ}
+less.exe: ${OBJ}
 	${CC} ${LDFLAGS} -o $@ ${OBJ} ${LIBS}
 
-lesskey: lesskey.o lesskey_parse.o version.o xbuf.o
+lesskey.exe: lesskey.o lesskey_parse.o version.o xbuf.o
 	${CC} ${LDFLAGS} -o $@ lesskey.o lesskey_parse.o version.o xbuf.o
 
-lessecho: lessecho.o version.o
+lessecho.exe: lessecho.o version.o
 	${CC} ${LDFLAGS} -o $@ lessecho.o version.o
+
+lessecho.o version.o: less.h defines.h funcs.h
 
 defines.h: defines.wn
 	${CP} $< $@
 
 funcs.h: ${LESS_SRC}
-	-${MV} funcs.h funcs.h.old
-	grep -h "^public [^;]*$$" ${LESS_SRC} | sed "s/$$/;/" >funcs.h
+	-${CP} funcs.h funcs.h.old
+	grep -h "^public [^;]*$$" ${LESS_SRC} | sed "s/$$/;/" >funcs.h.tmp
+	${DIFF} funcs.h.tmp funcs.h || ${MV} funcs.h.tmp funcs.h
 
 help.c: less.hlp
 	(perl mkhelp.pl || sh mkhelp.sh)  < $<  > $@


### PR DESCRIPTION
Several changes:

- Remove "clean" from target "all": not generally required, and also prevents incremental and/or parallel build, e.g. with -j8, because the binaries don't depend on "clean" (rightfully), and so make ... [all] can clean generated files while they're being used.

- lessecho objects depend on less.h et-al, so formalize it.

- Add ".exe" to the targets: this serves two porposes:
  - Windows gnu make doesn't realise that e.g. the target "less" is "less.exe", so it's linked every time because "less" is missing.
  - When cross compiling, not all mingw compilers realize that -o foo should create foo.exe . Now it's explicit.

- funcs.h: touch it only if it's actually modified. funcs.h rightfully depends on all the less source files, and all the objects rightfully depend on funcs.h, so every change to any source file resulted in rebuilding all other sources. However, most changes to source files don't actually result in modified funcs.h. Now source changes result in full rebuild only if funcs.h is actually modified.

  Note that running "make" again after all the targets are satisfied is still likely to make the "funcs.h" target, because it's likely older than some source files, but because that wouldn't actually touch funcs.h - other targets remain satisfied.