### PR TITLE
Enable support for IBM z/OS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -65,10 +65,10 @@ less$(EXEEXT): ${OBJ}
 	${CC} ${LDFLAGS} -o $@ ${OBJ} ${LIBS}
 
 lesskey$(EXEEXT): lesskey.${O} lesskey_parse.${O} xbuf.${O} version.${O}
-	${CC} ${LDFLAGS} -o $@ lesskey.${O} lesskey_parse.${O} xbuf.${O} version.${O}
+	${CC} ${LDFLAGS} -o $@ lesskey.${O} lesskey_parse.${O} xbuf.${O} version.${O} ${LIBS}
 
 lessecho$(EXEEXT): lessecho.${O} version.${O}
-	${CC} ${LDFLAGS} -o $@ lessecho.${O} version.${O}
+	${CC} ${LDFLAGS} -o $@ lessecho.${O} version.${O} ${LIBS}
 
 charset.${O}: compose.uni ubin.uni wide.uni
 

--- a/edit.c
+++ b/edit.c
@@ -16,7 +16,7 @@
 #if HAVE_SYS_WAIT_H
 #include <sys/wait.h>
 #endif
-#if OS2 || (defined WIFSIGNALED && defined WTERMSIG)
+#if OS2 || __MVS__ || (defined WIFSIGNALED && defined WTERMSIG)
 #include <signal.h>
 #endif
 
@@ -305,11 +305,7 @@ static void close_pipe(FILE *pipefd)
 	if (WIFSIGNALED(status))
 	{
 		int sig = WTERMSIG(status);
-		if (
-#ifdef SIGPIPE
-      sig != SIGPIPE ||
-#endif
-      ch_length() != NULL_POSITION)
+		if (sig != SIGPIPE || ch_length() != NULL_POSITION)
 		{
 			parg.p_string = signal_message(sig);
 			error("Input preprocessor terminated: %s", &parg);

--- a/edit.c
+++ b/edit.c
@@ -305,7 +305,11 @@ static void close_pipe(FILE *pipefd)
 	if (WIFSIGNALED(status))
 	{
 		int sig = WTERMSIG(status);
-		if (sig != SIGPIPE || ch_length() != NULL_POSITION)
+		if (
+#ifdef SIGPIPE
+      sig != SIGPIPE ||
+#endif
+      ch_length() != NULL_POSITION)
 		{
 			parg.p_string = signal_message(sig);
 			error("Input preprocessor terminated: %s", &parg);

--- a/lesstest/Makefile
+++ b/lesstest/Makefile
@@ -10,12 +10,12 @@ LESSTEST_SRC = display.c env.c lesstest.c parse.c pipeline.c log.c run.c term.c 
 LESSTEST_OBJ = $(patsubst %.c,%.o,$(LESSTEST_SRC))
 
 lesstest: $(LESSTEST_OBJ)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o lesstest $(LESSTEST_OBJ) $(TERMLIB)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o lesstest $(LESSTEST_OBJ) $(TERMLIB) $(LIBS)
 
 LT_SCREEN_SRC = lt_screen.c unicode.c wchar.c
 LT_SCREEN_OBJ = $(patsubst %.c,%.o,$(LT_SCREEN_SRC))
 lt_screen: $(LT_SCREEN_OBJ)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o lt_screen $(LT_SCREEN_OBJ)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o lt_screen $(LT_SCREEN_OBJ) $(LIBS)
 
 HDR = lesstest.h lt_types.h wchar.h
 *.o: $(HDR)

--- a/ttyin.c
+++ b/ttyin.c
@@ -83,6 +83,10 @@ public int open_tty(void)
 		fd = open_tty_device("/dev/tty");
 	if (fd < 0)
 		fd = 2;
+#ifdef __MVS__
+	struct f_cnvrt cvtreq = {SETCVTON, 0, 1047};
+	fcntl(fd, F_CONTROL_CVT, &cvtreq);
+#endif
 	return fd;
 }
 #endif /* MSDOS_COMPILER */


### PR DESCRIPTION
IBM z/OS is a mainframe operating system. 
Changes include:
- z/OS stdout/stderr file descriptors need to be tagged as IBM 1047 to ensure proper conversion
- We pass in an additional library, zoslib, which provides compat with glibc, therefore we need to pass $LIBS in links steps in Makefile.in/Makefile
- Include signal.h for z/OS (`__MVS__`) so that SIGPIPE is available
