### PR TITLE
handle Linux tracefs files correctly, like procfs

### DIFF
--- a/ch.c
+++ b/ch.c
@@ -718,21 +718,27 @@ public void ch_flush(void)
 
 #if HAVE_PROCFS
 	/*
-	 * This is a kludge to workaround a Linux kernel bug: files in
-	 * /proc have a size of 0 according to fstat() but have readable 
-	 * data.  They are sometimes, but not always, seekable.
-	 * Force them to be non-seekable here.
+	 * This is a kludge to workaround a Linux kernel bug: files in some
+	 * pseudo filesystems like /proc and tracefs have a size of 0
+	 * according to fstat() but have readable data.  They are sometimes,
+	 * but not always, seekable. Force them to be non-seekable here.
 	 */
 	if (ch_fsize == 0)
 	{
 		struct statfs st;
 		if (fstatfs(ch_file, &st) == 0)
 		{
+#if HAVE_TRACEFS
+			if (st.f_type == PROC_SUPER_MAGIC ||
+			    st.f_type == TRACEFS_MAGIC)
+#else
 			if (st.f_type == PROC_SUPER_MAGIC)
+#endif
 			{
 				ch_fsize = NULL_POSITION;
 				ch_flags &= ~CH_CANSEEK;
 			}
+
 		}
 	}
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -207,7 +207,9 @@ AH_TEMPLATE([HAVE_CONST],
 AH_TEMPLATE([HAVE_STAT_INO],
 	[Define HAVE_STAT_INO if your struct stat has st_ino and st_dev.])
 AH_TEMPLATE([HAVE_PROCFS],
-	[Define HAVE_PROCFS if have have fstatfs with f_type and PROC_SUPER_MAGIC.])
+	[Define HAVE_PROCFS if you have fstatfs with f_type and PROC_SUPER_MAGIC.])
+AH_TEMPLATE([HAVE_TRACEFS],
+	[Define HAVE_TRACEFS if you have fstatfs with f_type and TRACEFS_MAGIC.])
 AH_TEMPLATE([HAVE_TIME_T],
 	[Define HAVE_TIME_T if your system supports the "time_t" type.])
 AH_TEMPLATE([HAVE_STRERROR],
@@ -256,6 +258,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/statfs.h>
 #if HAVE_LINUX_MAGIC_H
 #include <linux/magic.h>
 #endif]], [[struct statfs s; s.f_type = PROC_SUPER_MAGIC; (void) fstatfs(0,&s); ]])],[AC_MSG_RESULT(yes); AC_DEFINE(HAVE_PROCFS)],[AC_MSG_RESULT(no)])
+AC_MSG_CHECKING(for tracefs)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/statfs.h>
+#if HAVE_LINUX_MAGIC_H
+#include <linux/magic.h>
+#endif]], [[struct statfs s; s.f_type = TRACEFS_MAGIC; (void) fstatfs(0,&s); ]])],[AC_MSG_RESULT(yes); AC_DEFINE(HAVE_TRACEFS)],[AC_MSG_RESULT(no)])
 
 # Checks for ANSI function prototypes.
 AC_MSG_CHECKING(for ANSI function prototypes)


### PR DESCRIPTION
less already correctly handles files in procfs that claim to have 0 length, but the tracefs filesystem has similar files that report 0 length but have data. This adds support for the Linux tracefs filesystem.