### PR TITLE
Do not assume PATH_MAX is defined

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -768,9 +768,24 @@ public char * lrealpath(constant char *path)
 	if (!is_fake_pathname(path))
 	{
 #if HAVE_REALPATH
+		/*
+		 * Not all systems support the POSIX.1-2008 realpath() behavior
+		 * of allocating when passing a NULL argument. And PATH_MAX is
+		 * not required to be defined, or might contain an exceedingly
+		 * big value. We assume that if it is not defined (such as on
+		 * GNU/Hurd), then realpath() accepts NULL.
+		 */
+#ifndef PATH_MAX
+		char *rpath;
+
+		rpath = realpath(path, NULL);
+		if (rpath != NULL)
+			return (rpath);
+#else
 		char rpath[PATH_MAX];
 		if (realpath(path, rpath) != NULL)
 			return (save(rpath));
+#endif
 #endif
 	}
 	return (save(path));


### PR DESCRIPTION
On systems such as GNU/Hurd, PATH_MAX is not defined, because the system intends to impose no arbitrary limits. In other systems though it might be defined but to a very large value.

We can use realpath() with its POSIX.1-2008 semantics, where passing a NULL argument will make it allocate the destination buffer, but not all systems support these semantics yet.

For now, instead of complicating the code to cope with realpath() limitations on some systems, we simply handle the case where PATH_MAX is not defined, where realpath() should always support these semantics.