### PR TITLE
Added more formatting attributes for -D

### DIFF
--- a/less.nro.VER
+++ b/less.nro.VER
@@ -679,6 +679,9 @@ the normal format change and the specified color should both be used.
 For example, \-Dug displays underlined text as green without underlining;
 the green color has replaced the usual underline formatting.
 But \-Du+g displays underlined text as both green and in underlined format.
+Other special characters are * for bold mode, _ for underline mode, & for blink
+mode, and ~ for standout mode.
+Thus, \-Du_*g displays underlined text as green, underlined and bold.
 .PP
 \fIcolor\fP is either a 4-bit color string or an 8-bit color string:
 .PP

--- a/screen.c
+++ b/screen.c
@@ -2483,7 +2483,7 @@ public COLOR_TYPE parse_color(constant char *str, int *p_fg, int *p_bg)
 
 	if (str == NULL || *str == '\0')
 		return CT_NULL;
-	if (*str == '+')
+	while (*str == '+' || *str == '_' || *str == '*' || *str == '~' || *str == '&')
 		str++; /* ignore leading + */
 
 	fg = parse_color4(str[0]);
@@ -2576,11 +2576,22 @@ static void tput_inmode(constant char *mode_str, int attr, int attr_bit, int (*f
 	if ((attr & attr_bit) == 0)
 		return;
 	color_str = get_color_map(attr_bit);
-	if (color_str == NULL || *color_str == '\0' || *color_str == '+')
+	enum lbool is_valid_mod = FALSE;
+	while (color_str == NULL || *color_str == '\0' || (is_valid_mod = *color_str == '+' || *color_str == '*' || *color_str == '_' || *color_str == '~' || *color_str == '&'))
 	{
-		ltputs(mode_str, 1, f_putc);
-		if (color_str == NULL || *color_str++ != '+')
+		if (*color_str == '*')
+			ltputs(sc_b_in, 1, f_putc);
+		else if (*color_str == '&')
+			ltputs(sc_bl_in, 1, f_putc);
+		else if (*color_str == '~')
+			ltputs(sc_s_in, 1, f_putc);
+		else if (*color_str == '_')
+			ltputs(sc_u_in, 1, f_putc);
+		else
+			ltputs(mode_str, 1, f_putc);
+		if (color_str == NULL || !is_valid_mod)
 			return;
+		color_str++;
 	}
 	/* Color overrides mode string */
 	tput_color(color_str, f_putc);


### PR DESCRIPTION
I was noticing that you can now use --color/-D to set colors, which is so much nicer than the LESS_TERMCAP_<x> environment variables.  However, there was something missing; with the environment variables, I make blinking text bold instead of blinking, but that didn't seem to be possible with -D, so I added it.

The new symbols * and _ for bold and underline are based on common convention/Markdown.  ~ for standout comes from the C not bitwise operator (since terminals tend to reverse the colors in standout mode; I originally made it \ but I thought that might get confused with an escape character; some Markdown dialects use ~ for strikethrough, so ~ might not be the best choice either). & for blink is arbitrary.

This PR however does have one limitation:  It still only works for lowercase letters.  It's still not possible to make the prompt bold, for example.  I might look into why later.