### PR TITLE
Misleading usage syntax

### DIFF
--- a/less.hlp
+++ b/less.hlp
@@ -212,7 +212,7 @@
                   Set shell quote characters.
   -~  ........  --tilde
                   Don't display tildes after end of file.
-  -# [_N]  ....  --shift=[_N]
+  -# [_N]  ....  --shift=_N
                   Set horizontal scroll amount (0 = one half screen width).
                 --exit-follow-on-close
                   Exit F command on a pipe when writer closes pipe.
@@ -220,7 +220,7 @@
                   Automatically determine the size of the input file.
                 --follow-name
                   The F command changes files if the input file is renamed.
-                --header=[_L[,_C[,_N]]
+                --header=_L[,_C[,_N]]
                   Use _L lines (starting at line _N) and _C columns as headers.
                 --incsearch
                   Search file as each pattern character is typed in.


### PR DESCRIPTION
The option shift is like line-num-width, match-shift and modelines. Also the brackets are unbalanced.
However the manual says "If L is empty or missing, the number of  header  lines is unchanged." but
```
$ less --header=
Value is required after --header