### PR TITLE
dos: fix djgpp build

### DIFF
--- a/Makefile.dsg
+++ b/Makefile.dsg
@@ -53,7 +53,7 @@ lessecho: lessecho.${O} version.${O}
 	${CC} ${LDFLAGS} -o $@ lessecho.${O} version.${O}
 
 defines.h: defines.ds
-	command.com /c copy $< $@
+	command.com /c copy $< $@ || cmd.exe /c copy $< $@ || cp $< $@
 
 ${OBJ}: ${srcdir}/less.h defines.h ${srcdir}/funcs.h
 

--- a/output.c
+++ b/output.c
@@ -237,7 +237,11 @@ static void set_win_colors(t_sgr *sgr)
 
 static void win_flush(void)
 {
-	if (ctldisp != OPT_ONPLUS || (vt_enabled && sgr_mode))
+	if (ctldisp != OPT_ONPLUS
+#if MSDOS_COMPILER==WIN32C
+	    || (vt_enabled && sgr_mode)
+#endif
+	   )
 		WIN32textout(obuf, ptr_diff(ob, obuf));
 	else
 	{

--- a/screen.c
+++ b/screen.c
@@ -3190,10 +3190,12 @@ public void WIN32textout(constant char *text, size_t len)
 	} else
 		WriteConsole(con_out, text, len, &written, NULL);
 #else
-	char c = text[len];
-	text[len] = '\0';
-	cputs(text);
-	text[len] = c;
+	char buf[2048];
+	if (len >= sizeof(buf))
+		len = sizeof(buf) - 1;
+	memcpy(buf, text, len);
+	buf[len] = 0;
+	cputs(buf);
 #endif
 }
 #endif


### PR DESCRIPTION
Only DJGPP build was tested, but these changes should help other dos build envs too.

There were two issues:
- undefined vt_enabled at win_flush() at output.c .
- Write to read-only memory ("text") at WIN32textout() at screen.c .

And, the DJGPP Makefile.dsg explicitly invokes command.com /c copy ... so try also cmd.exe and (*nix) cp, so that it can also cross-compile.

Note that command.com is also used explicitly at the make targets clean, distclean, realclean, and it remains unmodified, so those will not work when cross compiling on Windows or *nix, but one can always clean the build manually.

Also, Makefile.dsg doesn't generate funcs.h and help.c, so they should exist (e.g. a release tarball) or using e.g. Makefile.{aut|wng}.

The build was very smooth, without even a single warning.

Tested in dosbox after (cross) compiling with DJGPP, and with the DJGPP dpmi exe at the same dir (CWS{DPMI,DPR0,DSTR0,DSTUB,PARAM}.EXE).

Colors/SGR (at the help page, and with -R) seem to work fine too.

UTF-8 displays broken by default, which I guess is expected.

Used DJGPP tools (gcc 12.2): https://github.com/andrewwutw/build-djgpp