### PR TITLE
lesskey.nro.VER: Fix another minor markup issue

### DIFF
--- a/lesskey.nro.VER
+++ b/lesskey.nro.VER
@@ -432,7 +432,7 @@ In those older versions, all #version lines are ignored.
 .
 .SH EXAMPLE
 The following input file sets the \-i and \-S options when
-.less
+.B less
 is run and, on version 595 and higher, adds a \-\-color option.
 .sp
 .nf


### PR DESCRIPTION
Commit 874f1bc (PR #490) missed another man macro issue, introduced in commit f49c787.

Found using:

    $ man --warnings ./lesskey.nro.VER 1>/dev/null
    troff: <standard input>:435: warning: macro 'less' not defined