### PR TITLE
Disable "more" compatibility with LESS_IS_MORE=0

### DIFF
--- a/less.nro.VER
+++ b/less.nro.VER
@@ -2289,7 +2289,8 @@ In that case, the LESSSECURE and LESSSECURE_ALLOW variables are ignored.
 .
 .SH "COMPATIBILITY WITH MORE"
 If the environment variable LESS_IS_MORE is set to 1,
-or if the program is invoked via a file link named "more",
+or if the program is invoked via a file link named "more"
+and the environment variable LESS_IS_MORE is not set to 0,
 .B less
 behaves (mostly) in conformance with the POSIX 
 .BR more (1)

--- a/main.c
+++ b/main.c
@@ -294,7 +294,8 @@ int main(int argc, constant char *argv[])
 	 * If the name of the executable program is "more",
 	 * act like LESS_IS_MORE is set.
 	 */
-	if (strcmp(last_component(progname), "more") == 0)
+	if (strcmp(last_component(progname), "more") == 0 &&
+			isnullenv(lgetenv("LESS_IS_MORE")))
 		less_is_more = 1;
 
 	init_prompt();

--- a/opttbl.c
+++ b/opttbl.c
@@ -748,7 +748,7 @@ public void init_option(void)
 	constant char *p;
 
 	p = lgetenv("LESS_IS_MORE");
-	if (!isnullenv(p))
+	if (!isnullenv(p) && p[0] == '1' && p[1] == '\0')
 		less_is_more = 1;
 
 	for (o = option;  o->oletter != '\0';  o++)


### PR DESCRIPTION
A Debian user [reported][1] in 2007 that he has always invoked less as "more" but that the "more" compatibility mode introduced in commit 08a5ba8 didn't work for him.  He requested the ability to disable it, and Debian has carried his patch ever since.  This change is the same patch, forward-ported following commit 5354c92 and with a documentation update.

Example (in source tree):

    $ ln -s less more
    $ LESS_IS_MORE=0 ./more main.c

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=434417