### PR TITLE
doc: Remove claim that "more" can't move backward

### DIFF
--- a/less.nro.VER
+++ b/less.nro.VER
@@ -27,10 +27,8 @@ less \- display the contents of a file in a terminal
 .B Less
 is a program similar to
 .BR more (1),
-but which allows backward movement
-in the file as well as forward movement.
-Also,
-.B less
+but it has many more features.
+.B Less
 does not have to read the entire input file before starting,
 so with large input files it starts up faster than text editors like
 .BR vi (1).


### PR DESCRIPTION
As [suggested][1] by a Debian user in 2012.

POSIX [specifies][2] that "more" can scroll backward.

util-linux's "more", added in [version 1.6][3], was copied from [system-0.98.tar.Z][4], where "CREDITS" says it came from BSD Net/2. "more" source code was released in 386BSD version 0.1, upon which NetBSD and FreeBSD were later based.

Both the Net/2-based version in system-0.98.tar.Z and [386BSD 0.1's "more"][5] supported [N]b or [N]^B to skip backward N pages.  In other words, apparently all versions of "more" since its first source code releases allow backward movement.

[1]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=655926
[2]: https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/more.html#tag_20_81_13_03
[3]: https://git.kernel.org/pub/scm/utils/util-linux/util-linux.git/tree/Notes.pre1995?id=6dbe3af94#n158
[4]: https://ftp.funet.fi/pub/Linux/tools/system-0.98.tar.Z
[5]: https://github.com/386bsd/386bsd/blob/0.1/usr/src/usr.bin/more/more.c#L1019