### PR TITLE
Fixed upstream #505 : spurious warning on adm5 terminal

### DIFF
--- a/screen.c
+++ b/screen.c
@@ -1431,11 +1431,9 @@ public void get_term(void)
 	t2 = ltgetstr("sr", &sp);
 	if (t2 == NULL)
 		t2 = "";
-#if OS2
 	if (*t1 == '\0' && *t2 == '\0')
 		sc_addline = "";
 	else
-#endif
 	if (above_mem)
 		sc_addline = t1;
 	else


### PR DESCRIPTION
Fix for issue #505 ("Wrong warning when running on Lear Siegler ADM-5 terminal")

The ``cheaper`` function that compares two ways of using termcap sets ``missing_cap`` to 1 if both ways are unavailable. This function is used to choose between using "al" or "sr" ("add line" or "scroll reverse") to add a line at the top of the screen. None of those are available on an ADM5 terminal.

However, ``less`` already has support for terminal that lacks reverse scroll, and is correctly setting the ``no_back_scroll``, making the warning wrong.

Source code already had a provision to avoid using ``cheaper`` if none of the capabilities were available, but it was only used for OS2. I enabled this for all builds. I don't see any potential for any regression.

