### PR TITLE
implement env var to offset onescreen cutoff less than full height

### DIFF
--- a/forwback.c
+++ b/forwback.c
@@ -20,6 +20,7 @@ public lbool squished;
 public int no_back_scroll = 0;
 public int forw_prompt;
 public int first_time = 1;
+public int onescreen_offset = 0;
 public lbool no_eof_bell = FALSE;
 
 extern int sigs;
@@ -88,7 +89,7 @@ public lbool eof_displayed(void)
 	 * If the bottom line ends at the file length,
 	 * we must be just at EOF.
 	 */
-	pos = position(BOTTOM_PLUS_ONE);
+	pos = position(onescreen_offset ? BOTTOM_OFFSET : BOTTOM_PLUS_ONE);
 	return (pos == NULL_POSITION || pos == ch_length());
 }
 
@@ -540,10 +541,17 @@ public int get_one_screen(void)
 	int nlines;
 	POSITION pos = ch_zero();
 
-	for (nlines = 0;  nlines < sc_height;  nlines++)
+	int offn, offheight;
+	const char *off = lgetenv("LESS_ONESCREEN_OFFSET");
+
+	offn = off == NULL ? 0 : atoi(off);
+	onescreen_offset = offn < 0 ? 0 : offn < sc_height ? offn : 0;
+	offheight = sc_height - onescreen_offset;
+
+	for (nlines = 0; nlines < offheight; nlines++)
 	{
 		pos = forw_line(pos);
 		if (pos == NULL_POSITION) break;
 	}
-	return (nlines < sc_height);
+	return (nlines < offheight);
 }

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -2503,6 +2503,12 @@ so scrolling may be slower.
 Duration (in milliseconds) after starting to read data from the input,
 after which the "Waiting for data" message will be displayed.
 The default is 4000 (4 seconds).
+.IP LESS_ONESCREEN_OFFSET
+Reduce the number of input lines needed to trigger paging with the \-F
+(\-\-quit-if-one-screen) option.  By default (value 0), paging happens only
+if the input exceeds one less lines than screen height.  Incrementing
+this value decreases that threshold.  Use if your shell prompt contains extra
+newlines, so no unpaged output scrolls off the screen.
 .IP LESS_IS_MORE
 Emulate the
 .BR more (1)

--- a/position.c
+++ b/position.c
@@ -26,6 +26,7 @@ static int table_size = 0;
 
 extern int sc_width, sc_height;
 extern int hshift;
+extern int onescreen_offset;
 
 /*
  * Return the starting file position of a line displayed on the screen.
@@ -45,6 +46,9 @@ public POSITION position(int sindex)
 		break;
 	case BOTTOM_PLUS_ONE:
 		sindex = sc_height - 1;
+		break;
+	case BOTTOM_OFFSET:
+		sindex = sc_height - onescreen_offset - 1;
 		break;
 	case MIDDLE:
 		sindex = (sc_height - 1) / 2;

--- a/position.h
+++ b/position.h
@@ -15,4 +15,5 @@
 #define TOP_PLUS_ONE    (1)
 #define BOTTOM          (-1)
 #define BOTTOM_PLUS_ONE (-2)
-#define MIDDLE          (-3)
+#define BOTTOM_OFFSET   (-3)
+#define MIDDLE          (-4)


### PR DESCRIPTION
The threshold size for `-F`/`--quit-if-onescreen` before paging is activated (and we do prompting) is currently `sc_height - 1`.  This hardcoded size does not allow for those who have a `$PS1` that includes a newline (to separate successive prompts with a blank line), or any other complex multi-line prompt, to use `-F` successfully without losing some lines off the top of the screen at the boundary size.  This should be paged to prevent loss of information (without scrolling back, the need for which would not be obvious since `-F` was used).

`less` does not know the user's prompt height without counting newlines in `$PS1`, which would not work with all shells (such as tcsh).  As a workaround, the submitted patch implements a `$LESS_ONESCREEN_OFFSET` environment variable so the user can inform `less`.  This variable, if a positive integer less than screen size, will add to the offset we look at to see if we're past EOF in `eof_displayed()`, as called by `entire_file_displayed()` while `quit_if_onescreen` is enabled to test if we should `quit()` early.

We have previously calculated the "new" shortened screen size to consider for early quit under `quit_if_onescreen`, by subtracting the provided offset during `get_one_screen()` determination.
