### PR TITLE
fix crash - buffer overflow by one in fexpand

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -368,7 +368,7 @@ static size_t fexpand_copy(constant char *fr, char *to)
 			xcpy_char(&xp, *fr);
 		}
 	}
-	if (xp.dest != NULL) xcpy_char(&xp, '\0');
+	xcpy_char(&xp, '\0');
 	return xp.copied;
 }
 


### PR DESCRIPTION
The symptom, on Windows, using LESSOPEN, was that "less" would sometimes (up to 5-10%) crash with exit code 116.

gdb detected heap block overflow in free(filename) in lglob.

The overflow is because fexpand_copy(s, NULL) return value (and allocated size) doesn't count the final \0, but fexpand_copy(s, x) does write a final \0.

This appears to be a regression of commit 1626d061, where fexpand_copy returned the strlen of the result, and fexpand allocated n+1, but commit 1626d061 changed the allocation to n.

Fix it by always counting the \0 - which appears to fix the crash.

fexpand_copy is only used from fexpand (once to count, and once for the actual copy), so there's no risk elsewhere from this change.