### PR TITLE
windows: don't search config files in CWD and $PATH

### DIFF
--- a/filename.c
+++ b/filename.c
@@ -288,7 +288,7 @@ public char * homefile(constant char *filename)
 	if (pathname != NULL)
 		return (pathname);
 #endif
-#if MSDOS_COMPILER || OS2
+#if (MSDOS_COMPILER && MSDOS_COMPILER!=WIN32C) || OS2
 	/* Look for the file anywhere on search path. */
 	pathname = (char *) ecalloc(_MAX_PATH, sizeof(char));
 #if MSDOS_COMPILER==DJGPPC


### PR DESCRIPTION
Config files, like _lesskey, are determined at homefile(...), and on windows, after trying $HOME and $HOMEDRIVE$HOMEPATH, it could fallback to using _searchenv, which first searches CWD and then in $PATH.

Disable this fallback on Windows.

Note that OS2 and DOS variants (DJGPP, Borland, MS-DOS-compiler) still behave like before, and search PWD and $PATH (assuming they still compile - all the non-DJGPP targets use and used _searchenv, which probably only exists on WIndows).

At the very least the DOS variants don't have a notion of $HOME, so it's not obvious where the config files should be searched - if we wanted to address these build targets as well, but for now we don't.