### PR TITLE
windows: advance more carefully while parsing SGR

### DIFF
--- a/output.c
+++ b/output.c
@@ -236,6 +236,12 @@ static void set_win_colors(t_sgr *sgr)
 	WIN32setcolors(fg, bg);
 }
 
+/* like is_ansi_end, but doesn't assume c != 0  (returns 0 for c == 0) */
+static int is_ansi_end_0(char c)
+{
+	return c && is_ansi_end((unsigned char)c);
+}
+
 static void win_flush(void)
 {
 	if (ctldisp != OPT_ONPLUS
@@ -294,7 +300,7 @@ static void win_flush(void)
 					anchor = p;
 				}
 				p += 2;  /* Skip the "ESC-[" */
-				if (is_ansi_end(*p))
+				if (is_ansi_end_0(*p))
 				{
 					/*
 					 * Handle null escape sequence
@@ -313,7 +319,7 @@ static void win_flush(void)
 				 * Parse and apply SGR values to the SGR state
 				 * based on the escape sequence. 
 				 */
-				while (!is_ansi_end(*p))
+				while (!is_ansi_end_0(*p))
 				{
 					char *q;
 					long code = strtol(p, &q, 10);
@@ -333,7 +339,7 @@ static void win_flush(void)
 					}
 
 					if (q == p ||
-						(!is_ansi_end(*q) && *q != ';'))
+						(!is_ansi_end_0(*q) && *q != ';'))
 					{
 						/*
 						 * can't parse. passthrough
@@ -355,7 +361,7 @@ static void win_flush(void)
 
 					p = q;
 				}
-				if (!is_ansi_end(*p) || p == p_next)
+				if (!is_ansi_end_0(*p) || p == p_next)
 					break;
 
 				if (sgr_bad_sync && vt_enabled) {

--- a/output.c
+++ b/output.c
@@ -79,7 +79,17 @@ public void put_line(void)
 	at_exit();
 }
 
+#if MSDOS_COMPILER==WIN32C || MSDOS_COMPILER==BORLANDC || MSDOS_COMPILER==DJGPPC
+/*
+ * win_flush has at least one non-critical issue when an escape sequence
+ * begins at the last char of the buffer, and possibly more issues.
+ * as a temporary measure to reduce likelyhood of encountering end-of-buffer
+ * issues till the SGR parser is replaced, use bigger (8K) buffer.
+ */
+static char obuf[OUTBUF_SIZE * 8];
+#else
 static char obuf[OUTBUF_SIZE];
+#endif
 static char *ob = obuf;
 static int outfd = 2; /* stderr */
 

--- a/output.c
+++ b/output.c
@@ -332,8 +332,7 @@ static void win_flush(void)
 						 * in the buffer.
 						 */
 						size_t slop = ptr_diff(q, anchor);
-						/* {{ strcpy args overlap! }} */
-						strcpy(obuf, anchor);
+						memmove(obuf, anchor, slop);
 						ob = &obuf[slop];
 						return;
 					}


### PR DESCRIPTION
The SGR processor parses an input buffer for SGR sequences, and not
all the places which advanced the data pointer checked whether it
reached the end of the buffer (EOB - first byte past the buffer).

If it did reach the EOB and we didn't realize it, then it could
result, depending on how the stars align, in a crash (because the
code updates global pointers with some prtdiffs, and if the diff
is negative because we weren't careful then all bets are off).

With a specific test file which resulted in a crash, the first
offending advancement which reached EOB untested was:
```c
  if (*q == ';')
      q++;
```
However, looking at the code, there seem to be more places where
potentially bad advancements were not protected.

This commit adds several advancement protections, and fixes the crash.

It's possible that it's over-careful and that some of the tests are
always "no problem", or even that all of them are not required except
that one "q++" advancement which we know can reach EOB.

But this code is complex, and it's better to be on the safe side.
If a test is always "no problem", then no problem, it's no-op.

This addresses the issue mentioned at https://github.com/gwsw/less/pull/539#issuecomment-2241727530