### PR TITLE
windows: increase WIN32textout internal buffer

### DIFF
--- a/defines.wn
+++ b/defines.wn
@@ -196,7 +196,7 @@
 #define	CMDBUF_SIZE	2048	/* Buffer for multichar commands */
 #define	UNGOT_SIZE	200	/* Max chars to unget() */
 #define	LINEBUF_SIZE	1024	/* Initial max size of line in input file */
-#define	OUTBUF_SIZE	1024	/* Output buffer */
+#define	OUTBUF_SIZE	8192	/* Output buffer: 8K avoids end-of-buffer bugs in win_flush */
 #define	PROMPT_SIZE	2048	/* Max size of prompt string */
 #define	TERMBUF_SIZE	2048	/* Termcap buffer for tgetent */
 #define	TERMSBUF_SIZE	1024	/* Buffer to hold termcap strings */

--- a/output.c
+++ b/output.c
@@ -79,17 +79,13 @@ public void put_line(void)
 	at_exit();
 }
 
-#if MSDOS_COMPILER==WIN32C || MSDOS_COMPILER==BORLANDC || MSDOS_COMPILER==DJGPPC
 /*
  * win_flush has at least one non-critical issue when an escape sequence
  * begins at the last char of the buffer, and possibly more issues.
  * as a temporary measure to reduce likelyhood of encountering end-of-buffer
- * issues till the SGR parser is replaced, use bigger (8K) buffer.
+ * issues till the SGR parser is replaced, OUTBUF_SIZE is 8K on Windows.
  */
-static char obuf[OUTBUF_SIZE * 8];
-#else
 static char obuf[OUTBUF_SIZE];
-#endif
 static char *ob = obuf;
 static int outfd = 2; /* stderr */
 

--- a/screen.c
+++ b/screen.c
@@ -3193,8 +3193,11 @@ public void WIN32textout(constant char *text, size_t len)
 		/*
 		 * We've got UTF-8 text in a non-UTF-8 console.  Convert it to
 		 * wide and use WriteConsoleW.
+		 * Biggest input len is OUTBUF_SIZE of obuf from win_flush,
+		 * which is also the biggest output count if it's ASCII.
+		 * "static" wtext is not a state - only avoid 16K on stack.
 		 */
-		WCHAR wtext[1024];
+		static WCHAR wtext[OUTBUF_SIZE];
 		len = MultiByteToWideChar(CP_UTF8, 0, text, len, wtext, countof(wtext));
 		WriteConsoleW(con_out, wtext, len, &written, NULL);
 	} else


### PR DESCRIPTION
By default (*), the main console output (from win_flush using WIN32textout) is converted from UTF-8 to wchar_t.

The conversion uses a fixed-size buffer which was 1024, and now is 8K.

The size increase is required because win_flush can output the whole buffer in one call, especially with -Da where the internal SGR processor is bypassed - obuf is sent unmodified to WIN32textout.

obuf was changed recently from 1024 to 8K in commit 5854746 (windows: SGR processor: increase buffer size for less issues), and because the WIN32textout buffer did not increase till now, it could result in failed conversion due to insufficient result buffer, and no output.

Before 5854746, OUTBUF_SIZ was 1024 and used only for obuf, while the WIN32textout buffer was independently and luckily also 1024.

Now both obuf and WIN32textout use the same size OUTBUF_SIZE (which is not used elsewhere), and its 8K value is set in defines.wn .

(*) If the internal "less" charset is UTF8 (default on Windows), and
    the console output CP is not UTF8 (also default), then conversion
    from UTF8 to wchar_t happens before using WriteConsoleW.