### PR TITLE
Man pages: .UR and .UE macro used to format URLs.

### DIFF
--- a/less.nro.VER
+++ b/less.nro.VER
@@ -789,9 +789,8 @@ where the first integer specifies the foreground color and
 the second specifies the background color.
 Each integer is a value between 0 and 255 inclusive which selects
 a "CSI 38;5" color value (see
-.nh
-https://en.wikipedia.org/wiki/ANSI_escape_code#SGR).
-.hy
+.UR https://en.wikipedia.org/wiki/ANSI_escape_code#SGR
+.UE ).
 If either integer is a "-" or is omitted,
 the corresponding color is set to that of normal text.
 .PP
@@ -825,9 +824,8 @@ CHAR_INFO.Attributes
 .hy
 value, between 0 and 15 inclusive
 (see 
-.nh
-https://learn.microsoft.com/en-us/windows/console/char-info-str).
-.hy
+.UR https://learn.microsoft.com/en-us/windows/console/char-info-str
+.UE ).
 
 To avoid confusion, it is recommended that the equivalent letters rather than numbers
 be used after a lowercase color selector on MS-DOS/Windows.
@@ -1200,9 +1198,8 @@ the name of a command compatible with
 .BR global (1),
 and that command is executed to find the tag.
 (See 
-.nh
-http://www.gnu.org/software/global/global.html).
-.hy
+.UR http://www.gnu.org/software/global/global.html
+.UE ).
 The \-t option may also be specified from within
 .B less
 (using the \- command) as a way of examining a new file.
@@ -1587,9 +1584,8 @@ Enables colored text in various places.
 The \-D option can be used to change the colors.
 Colored text works only if the terminal supports 
 ANSI color escape sequences (as defined in 
-.nh
-https://www.ecma-international.org/publications-and-standards/standards/ecma-48).
-.hy
+.UR https://www.ecma-international.org/publications-and-standards/standards/ecma-48
+.UE ).
 .IP "\-\-wheel-lines=\fIn\fP"
 Set the number of lines to scroll when the mouse wheel is scrolled
 and the \-\-mouse or \-\-MOUSE option is in effect.
@@ -2626,12 +2622,10 @@ See the GNU General Public License for more details.
 Mark Nudelman
 .br
 Report bugs at 
-.nh
-https://github.com/gwsw/less/issues.
-.hy
+.UR https://github.com/gwsw/less/issues
+.UE .
 .br
 For more information, see the less homepage at
 .br
-.nh
-https://greenwoodsoftware.com/less.
-.hy
+.UR https://greenwoodsoftware.com/less
+.UE .

--- a/lessecho.nro.VER
+++ b/lessecho.nro.VER
@@ -53,4 +53,6 @@ The default is that only arguments containing metacharacters are quoted.
 This manual page was written by Thomas Schoepf <schoepf@debian.org>,
 for the Debian GNU/Linux system (but may be used by others).
 .PP
-Report bugs at https://github.com/gwsw/less/issues.
+Report bugs at 
+.UR https://github.com/gwsw/less/issues
+.UE .

--- a/lesskey.nro.VER
+++ b/lesskey.nro.VER
@@ -481,4 +481,6 @@ See the GNU General Public License for more details.
 .
 Mark Nudelman
 .br
-Report bugs at https://github.com/gwsw/less/issues.
+Report bugs at 
+.UR https://github.com/gwsw/less/issues
+.UE .


### PR DESCRIPTION
.UR and .UE macros are intended to format URLs in man pages. They render URLs in angle brackets, e. g.:

```
AUTHOR
       Mark Nudelman
       Report bugs at ⟨https://github.com/gwsw/less/issues⟩.
       For more information, see the less homepage at
       ⟨https://greenwoodsoftware.com/less⟩.
```

Such formatting helps to handle links properly. Now many terminal emulators recognizes URLs and allow the user to click on a link to open it in a web browser. Without angle brackets, the trailing dot is recognized as a part of the URL, it causes 404 error.