### PR TITLE
Inherit DESTDIR from the environment.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -41,7 +41,6 @@ datarootdir = @datarootdir@
 mandir = @mandir@
 manext = 1
 manprefix = 
-DESTDIR =
 
 #### End of system configuration section. ####
 


### PR DESCRIPTION
Makefiles conventionally inherit DESTDIR from the environment rather than requiring it to be specified as an explicit command line parameter.