### PR TITLE
fix: don't twiddle null lines during `quit_if_one_screen` render

### DIFF
--- a/line.c
+++ b/line.c
@@ -93,7 +93,6 @@ extern int linenums;
 extern int ctldisp;
 extern int twiddle;
 extern int quit_if_one_screen;
-extern int one_screen;
 extern int status_col;
 extern int status_col_width;
 extern int linenum_width;
@@ -1588,7 +1587,7 @@ public int gline(size_t i, int *ap)
 		{
 
 			/* Don't bother if we're not actually paging. */
-			if(quit_if_one_screen && one_screen)
+			if(quit_if_one_screen)
 			{
 				return '\0';
 			}

--- a/line.c
+++ b/line.c
@@ -92,6 +92,8 @@ extern int proc_return;
 extern int linenums;
 extern int ctldisp;
 extern int twiddle;
+extern int quit_if_one_screen;
+extern int one_screen;
 extern int status_col;
 extern int status_col_width;
 extern int linenum_width;
@@ -1584,6 +1586,13 @@ public int gline(size_t i, int *ap)
 		 */
 		if (twiddle)
 		{
+
+			/* Don't bother if we're not actually paging. */
+			if(quit_if_one_screen && one_screen)
+			{
+				return '\0';
+			}
+
 			if (i == 0)
 			{
 				*ap = AT_BOLD;


### PR DESCRIPTION
don't output tildes or blank lines if not paging a single-screen output

fixes https://github.com/gwsw/less/issues/624 

test cases:

```sh
seq 5 | less -F +G
echo "single line" | less -F +G --tilde
```