### PR TITLE
build: Make mingw build work properly from autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -604,9 +604,18 @@ AH_TOP([
 #define	LESSKEYINFILE_SYS	SYSDIR "/syslesskey"
 #define LESSHISTFILE		".lesshst"
 
+/* Autodetect mingw */
+#if defined(__MINGW32__)
+/*
+ * Define MSDOS_COMPILER if compiling under Microsoft C.
+ */
+#define	MSDOS_COMPILER	WIN32C
 
-/* Settings always true on Unix.  */
-
+/*
+ * Pathname separator character.
+ */
+#define	PATHNAME_SEP	"\\"
+#else
 /*
  * Define MSDOS_COMPILER if compiling under Microsoft C.
  */
@@ -616,6 +625,9 @@ AH_TOP([
  * Pathname separator character.
  */
 #define	PATHNAME_SEP	"/"
+#endif
+
+/* Settings always true on Unix.  */
 
 /*
  * The value returned from tgetent on success.

--- a/less.h
+++ b/less.h
@@ -216,7 +216,7 @@ void free();
  * Special types and constants.
  */
 typedef unsigned long LWCHAR;
-#if defined(MINGW) || (defined(_MSC_VER) && _MSC_VER >= 1500)
+#if defined(__MINGW32__) || (defined(_MSC_VER) && _MSC_VER >= 1500)
 typedef long long less_off_t;  /* __int64 */
 typedef struct _stat64 less_stat_t;
 #define less_fstat _fstat64

--- a/lglob.h
+++ b/lglob.h
@@ -56,7 +56,7 @@
                                         char ext[_MAX_EXT];     \
                                         int handle;
 #else
-#if MSDOS_COMPILER==WIN32C && (defined(_MSC_VER) || defined(MINGW))
+#if MSDOS_COMPILER==WIN32C && (defined(_MSC_VER) || defined(__MINGW32__))
 
 #define GLOB_FIRST_NAME(filename,fndp,h) h = _findfirst(filename, fndp)
 #define GLOB_FIRST_FAILED(handle)       ((handle) == -1)

--- a/lsystem.c
+++ b/lsystem.c
@@ -19,7 +19,7 @@
 
 #if MSDOS_COMPILER
 #include <dos.h>
-#if MSDOS_COMPILER==WIN32C && defined(MINGW)
+#if MSDOS_COMPILER==WIN32C && defined(__MINGW32__)
 #include <direct.h>
 #define setdisk(n) _chdrive((n)+1)
 #else

--- a/main.c
+++ b/main.c
@@ -17,7 +17,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-#if defined(MINGW) || defined(_MSC_VER)
+#if defined(__MINGW32__) || defined(_MSC_VER)
 #include <locale.h>
 #include <shellapi.h>
 #endif
@@ -78,7 +78,7 @@ extern int      redraw_on_quit;
 extern int      term_init_done;
 extern lbool    first_time;
 
-#if MSDOS_COMPILER==WIN32C && (defined(MINGW) || defined(_MSC_VER))
+#if MSDOS_COMPILER==WIN32C && (defined(__MINGW32__) || defined(_MSC_VER))
 /* malloc'ed 0-terminated utf8 of 0-terminated wide ws, or null on errors */
 static char *utf8_from_wide(constant wchar_t *ws)
 {
@@ -248,7 +248,7 @@ int main(int argc, constant char *argv[])
 	IFILE ifile;
 	constant char *s;
 
-#if MSDOS_COMPILER==WIN32C && (defined(MINGW) || defined(_MSC_VER))
+#if MSDOS_COMPILER==WIN32C && (defined(__MINGW32__) || defined(_MSC_VER))
 	if (GetACP() != CP_UTF8)  /* not using a UTF-8 manifest */
 		try_utf8_locale(&argc, &argv);
 #endif


### PR DESCRIPTION
This change makes a mingw build work from the standard autotools ./configure workflow. There are two mostly independent changes:
1. Change the mingw detection preprocessor macro to the standard `__MINGW32__` which is defined by the compiler (rather than expecting MINGW to be set by the defines header).
2. In the autotools-emitted defines.h make the values of MSDOS_COMPILER and PATHNAME_SEP appropriately automatically. This could of course also be detected with an autoconf macro, but the preprocessor version seemed simpler and just as correct.

I understand that there already is a spearate Makefile for mingw. However, it would be convenient to make the autotools version just work as well. In paprticular, I'm working on packaging less for https://github.com/JuliaPackaging/Yggdrasil. The system sets various defaults when it detects an autotools build. Of course, it would be possible to manually apply these for a mingw build, but it would be easier if the autotools build just worked.