### PR TITLE
Universal fix for flicker on horizontal scroll.

### DIFF
--- a/command.c
+++ b/command.c
@@ -2288,6 +2288,7 @@ public void commands(void)
 			pos_rehead();
 			hshift -= (int) number;
 			screen_trashed();
+			cmd_exec();
 			break;
 
 		case A_RSHIFT:
@@ -2301,6 +2302,7 @@ public void commands(void)
 			pos_rehead();
 			hshift += (int) number;
 			screen_trashed();
+			cmd_exec();
 			break;
 
 		case A_LLSHIFT:
@@ -2310,6 +2312,7 @@ public void commands(void)
 			pos_rehead();
 			hshift = 0;
 			screen_trashed();
+			cmd_exec();
 			break;
 
 		case A_RRSHIFT:
@@ -2319,6 +2322,7 @@ public void commands(void)
 			pos_rehead();
 			hshift = rrshift();
 			screen_trashed();
+			cmd_exec();
 			break;
 
 		case A_PREFIX:


### PR DESCRIPTION
This, somehow, significantly reduces flickering on horizontal scroll in flicker-sensitive terminals (like alacritty),
without needing to set SUSPEND and RESUME sequences (added in 77dddb2).

Separately, this also (mostly) prevents rendering (and flickering) of string representation printed in command line when handling left/right keys.

Related to #654.