### PR TITLE
Add z/OS compatibility improvements

### DIFF
--- a/charset.c
+++ b/charset.c
@@ -456,6 +456,12 @@ static void set_charset(void)
 	 * rather than from predefined charset entry.
 	 */
 	ilocale();
+#ifdef __MVS__
+/*
+	 * z/OS Locale does not properly support UTF-8. Default to "utf-8".
+*/
+  (void) icharset("utf-8", 1);
+#endif
 #else
 #if MSDOS_COMPILER
 #if MSDOS_COMPILER==WIN32C

--- a/edit.c
+++ b/edit.c
@@ -306,7 +306,11 @@ static void close_pipe(FILE *pipefd)
 	if (WIFSIGNALED(status))
 	{
 		int sig = WTERMSIG(status);
-		if (sig != SIGPIPE || ch_length() != NULL_POSITION)
+		if (
+#ifdef SIGPIPE
+      sig != SIGPIPE ||
+#endif
+      ch_length() != NULL_POSITION)
 		{
 			parg.p_string = signal_message(sig);
 			error("Input preprocessor terminated: %s", &parg);

--- a/os.c
+++ b/os.c
@@ -43,7 +43,7 @@ extern int errno;
 #include <sys/utsname.h>
 #endif
 
-#if HAVE_POLL && !MSDOS_COMPILER
+#if HAVE_POLL && !MSDOS_COMPILER && !defined(__MVS__)
 #define USE_POLL 1
 static lbool use_poll = TRUE;
 #else


### PR DESCRIPTION
This PR adds compatibility improvements to make the `less` utility work properly on z/OS systems. The changes address three specific issues that prevent proper operation on this platform.

## Changes
**UTF-8 charset support**: Added code to default to UTF-8 charset on z/OS systems since the z/OS locale implementation doesn't properly support UTF-8
**SIGPIPE handling**: Modified signal handling to conditionally check for SIGPIPE only when the signal is defined, as some systems (z/OS) may not define this signal
**poll() functionality**: Excluded z/OS systems from using poll which causes issues when going page up or down.

If you'd like to test these changes or improve upon them for z/OS, please let me know and I can get you access to a z/OS system.
