### PR TITLE
Mingw refinements

### DIFF
--- a/Makefile.wng
+++ b/Makefile.wng
@@ -98,6 +98,10 @@ endif
 
 LIBS += -lshell32
 
+CFLAGS += ${XCFLAGS}
+LDFLAGS += ${XLDFLAGS}
+LIBS += ${XLDLIBS}
+
 #### End of system configuration section. ####
 
 # This rule allows us to supply the necessary -D options


### PR DESCRIPTION
Two `Makefile.wng` minor changes: one only refines the regex comment, and the other adds some build flags options without changing the default behavior.