### PR TITLE
Port to shells lacking last command optimization

### DIFF
--- a/edit.c
+++ b/edit.c
@@ -264,6 +264,7 @@ static void close_pipe(FILE *pipefd)
 	int status;
 	char *p;
 	PARG parg;
+	int sig = 0;
 
 	if (pipefd == NULL)
 		return;
@@ -290,18 +291,36 @@ static void close_pipe(FILE *pipefd)
 	if (WIFEXITED(status))
 	{
 		int s = WEXITSTATUS(status);
-		if (s != 0)
+		if (s == 0)
+			return;
+		else if (s <= 128)
 		{
 			parg.p_int = s;
 			error("Input preprocessor failed (status %d)", &parg);
+			return;
 		}
-		return;
+		else
+		{
+			/*
+			 * popen invoked the shell, which likely last ran a
+			 * program that terminated due to a signal.
+			 * Assume the longstanding tradition (allowed but not
+			 * required by POSIX) of adding 128 to the signal.
+			 * Many shells use last command optimization, i.e.,
+			 * they exec the last command instead of forking and
+			 * waiting for it, and in that case the more-reliable
+			 * WIFSIGNALED code below will be used.
+			 */
+			sig = s - 128;
+		}
 	}
 #endif
 #if defined WIFSIGNALED && defined WTERMSIG
 	if (WIFSIGNALED(status))
+		sig = WTERMSIG(status);
+#endif
+	if (sig != 0)
 	{
-		int sig = WTERMSIG(status);
 		if (
 #ifdef SIGPIPE
 			sig != SIGPIPE || 
@@ -313,7 +332,6 @@ static void close_pipe(FILE *pipefd)
 		}
 		return;
 	}
-#endif
 	if (status != 0)
 	{
 		parg.p_int = status;


### PR DESCRIPTION
Problem reported by Leah Neukirchen in:
https://github.com/gwsw/less/issues/327#issuecomment-4170532225
* edit.c (close_pipe): Treat exit status > 128 as a signal that the subshell turned into status 128 + signal.  Although this behavior is not required by POSIX, it is longstanding practice and it works for all known shells that do not do last command optimization.