### PR TITLE
Handle malformed entry in special key processing

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -367,6 +367,8 @@ static void expand_special_keys(unsigned char *table, size_t len)
 			 */
 			repl = special_key_str(fm[1]);
 			klen = fm[2];
+			if (klen == 0)               /* malformed entry, abandon table */
+    			break;
 			fm += klen;
 			if (repl == NULL || strlen(repl) > klen)
 				repl = "\377";


### PR DESCRIPTION
Fix for malformed lesskey issue #763 in ```static void expand_special_keys(unsigned char *table, size_t len)```