### PR TITLE
Fixes #779: Argument injection less osc8

### DIFF
--- a/less-osc8-open.sh
+++ b/less-osc8-open.sh
@@ -43,6 +43,15 @@ open_man() {
 	man:?*\(*\) )
 		sect=${1#*\(}; sect=${sect%?}
 		name=${1#man:}; name=${name%%\(*}
+
+                case $sect in
+                    ''|[1-9]|[1-9][A-Za-z0-9]*)
+                        ;;
+                    *)
+                        echo "invalid man link section: $sect" >&2
+                        exit 1
+                        ;;
+                esac
 		man ${sect:+"$sect"} "$name"
 		;;
 

--- a/less-osc8-open.sh
+++ b/less-osc8-open.sh
@@ -46,13 +46,16 @@ open_man() {
 
                 case $sect in
                     ''|[1-9]|[1-9][A-Za-z0-9]*)
+                       case $sect in
+                           -* ) echo "invalid man link section: $sect" >&2; exit 1 ;;
+                        esac
                         ;;
                     *)
                         echo "invalid man link section: $sect" >&2
                         exit 1
                         ;;
                 esac
-		man ${sect:+"$sect"} "$name"
+		man ${sect:+"$sect"} -- "$name"
 		;;
 
 	man:?*)


### PR DESCRIPTION
The less-osc8-open.sh script was vulnerable to argument injection when handling OSC 8 man: URIs. This change adds validation to the section identifier to ensure it cannot be parsed as a command option by man.