### PR TITLE
Fix typo in uninstall rule.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -99,8 +99,8 @@ installdirs: mkinstalldirs
 uninstall:
 	rm -f ${DESTDIR}${bindir}/${binprefix}less$(EXEEXT)
 	rm -f ${DESTDIR}${bindir}/${binprefix}lesskey$(EXEEXT)
-	rm -f ${DESTDIR}${bindir}/${libexecprefix}lessecho$(EXEEXT)
-	rm -f ${DESTDIR}${bindir}/${libexecprefix}less-osc8-open
+	rm -f ${DESTDIR}${libexecdir}/${binprefix}lessecho$(EXEEXT)
+	rm -f ${DESTDIR}${libexecdir}/${binprefix}less-osc8-open
 	rm -f ${DESTDIR}${mandir}/man${manext}/${manprefix}less.${manext}
 	rm -f ${DESTDIR}${mandir}/man${manext}/${manprefix}lesskey.${manext}
 	rm -f ${DESTDIR}${mandir}/man${manext}/${manprefix}lessecho.${manext}


### PR DESCRIPTION
The `uninstall` Makefile rule attempts to remove the binaries in the libexec folder using the wrong variables.
Fix that by using the same variables that are used in the `install` Makefile rule for these binaries.