### PR TITLE
Add SPDX-License-Identifier tags to less source files

### DIFF
--- a/brac.c
+++ b/brac.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/ch.c
+++ b/ch.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/charset.c
+++ b/charset.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/charset.h
+++ b/charset.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/cmd.h
+++ b/cmd.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/cmdbuf.c
+++ b/cmdbuf.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/command.c
+++ b/command.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/cvt.c
+++ b/cvt.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/decode.c
+++ b/decode.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/edit.c
+++ b/edit.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/evar.c
+++ b/evar.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/filename.c
+++ b/filename.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/forwback.c
+++ b/forwback.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/ifile.c
+++ b/ifile.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/input.c
+++ b/input.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/jump.c
+++ b/jump.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lang.h
+++ b/lang.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/less.h
+++ b/less.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lessecho.c
+++ b/lessecho.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesskey.c
+++ b/lesskey.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesskey.h
+++ b/lesskey.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesskey_parse.c
+++ b/lesskey_parse.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/display.c
+++ b/lesstest/display.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/env.c
+++ b/lesstest/env.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/lesstest.c
+++ b/lesstest/lesstest.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/log.c
+++ b/lesstest/log.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/lt_screen.c
+++ b/lesstest/lt_screen.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/parse.c
+++ b/lesstest/parse.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/pipeline.c
+++ b/lesstest/pipeline.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/run.c
+++ b/lesstest/run.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/term.c
+++ b/lesstest/term.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/unicode.c
+++ b/lesstest/unicode.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lesstest/wchar.c
+++ b/lesstest/wchar.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lglob.h
+++ b/lglob.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/line.c
+++ b/line.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/linenum.c
+++ b/linenum.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/lsystem.c
+++ b/lsystem.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/main.c
+++ b/main.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/mark.c
+++ b/mark.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/optfunc.c
+++ b/optfunc.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/option.c
+++ b/option.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/option.h
+++ b/option.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/opttbl.c
+++ b/opttbl.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/os.c
+++ b/os.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/output.c
+++ b/output.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/pattern.c
+++ b/pattern.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/pattern.h
+++ b/pattern.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/pckeys.h
+++ b/pckeys.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/position.c
+++ b/position.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/position.h
+++ b/position.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/prompt.c
+++ b/prompt.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/regexp.c
+++ b/regexp.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: Spencer-86
+ *
  * regcomp and regexec -- regsub and regerror are elsewhere
  *
  *	Copyright (c) 1986 by University of Toronto.

--- a/screen.c
+++ b/screen.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/scrsize.c
+++ b/scrsize.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: X11 AND (GPL-3.0-or-later OR BSD-2-Clause)
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/search.c
+++ b/search.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/signal.c
+++ b/signal.c
@@ -1,5 +1,7 @@
 #include <errno.h>
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/tags.c
+++ b/tags.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/ttyin.c
+++ b/ttyin.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/version.c
+++ b/version.c
@@ -1,4 +1,7 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/xbuf.c
+++ b/xbuf.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public

--- a/xbuf.h
+++ b/xbuf.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: GPL-3.0-or-later OR BSD-2-Clause
+ *
  * Copyright (C) 1984-2026  Mark Nudelman
  *
  * You may distribute under the terms of either the GNU General Public


### PR DESCRIPTION
Less is mostly licensed under
 * GPL-3.0-or-later OR BSD-2-Clause

But there is couple exceptions:
 * **regexp.c is** under: Spencer-86
 * **scrsize.c** is under: X11 AND (GPL-3.0-or-later OR BSD-2-Clause)

This fixes: #778