### PR TITLE
Fix tty EOF handling

### DIFF
--- a/ttyin.c
+++ b/ttyin.c
@@ -216,14 +216,6 @@ public int getchr(void)
 		}
 		if (result == READ_INTR)
 			return (READ_INTR);
-		if (result == 0)
-		{
-			/*
-			 * EOF on the tty means there is no more keyboard input.
-			 * Don't loop forever waiting for a byte which cannot arrive.
-			 */
-			quit(QUIT_ERROR);
-		}
 		if (result < 0)
 		{
 			/*

--- a/ttyin.c
+++ b/ttyin.c
@@ -216,6 +216,14 @@ public int getchr(void)
 		}
 		if (result == READ_INTR)
 			return (READ_INTR);
+		if (result == 0)
+		{
+			/*
+			 * EOF on the tty means there is no more keyboard input.
+			 * Don't loop forever waiting for a byte which cannot arrive.
+			 */
+			quit(QUIT_ERROR);
+		}
 		if (result < 0)
 		{
 			/*


### PR DESCRIPTION
### Issue for this PR

Closes #793.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`getchr()` reads keyboard input in a loop until `iread()` returns one
byte. It already handles interrupted reads and negative errors, but it
does not handle EOF. Since `iread()` returns `read(2)` EOF unchanged,
closing the underlying tty/pty can leave `less` looping forever while no
input byte can arrive.

This change treats EOF from the tty input read as a fatal input condition
and exits through `quit(QUIT_ERROR)`, matching the nearby negative-error
path and avoiding a busy loop.

I chose direct `quit()` rather than returning `READ_INTR` because
`getccu()` converts negative `getchr()` results to NUL and loops while no
signal bit is set. Returning `READ_INTR` for EOF without also setting a
signal bit can move the spin to the caller instead of stopping it.

Related prior fixes/discussion:

- #558 fixed a separate EOF busy loop in the polling path.
- #719 fixed a separate prompt path when output is not a tty.
- junegunn/fzf#4667 reported preview processes involving `less` consuming
  CPU after preview shutdown.

### How did you verify your code works?

Built from a fresh checkout using the documented development path:

```sh
make -f Makefile.aut distfiles
sh configure
make
./less --version
```

The build completed and the built `less` binary reported version 704.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

PR template not found in `.github/pull_request_template.md`,
`.github/PULL_REQUEST_TEMPLATE/`, `.github/`, or `CONTRIBUTING.md`.