### PR TITLE
Document 'J', 'K', and 'Y' scroll commands in help.

### DIFF
--- a/less.hlp
+++ b/less.hlp
@@ -13,6 +13,8 @@
 
   e  ^E  j  ^N  CR  *  Forward  one line   (or _N lines).
   y  ^Y  k  ^K  ^P  *  Backward one line   (or _N lines).
+  J                 *  Forward  one line (or _N lines), but don't stop at end-of-file.
+  K  Y              *  Backward one line (or _N lines), but don't stop at beginning-of-file.
   ESC-j             *  Forward  one file line (or _N file lines).
   ESC-k             *  Backward one file line (or _N file lines).
   f  ^F  ^V  SPACE  *  Forward  one window (or _N lines).


### PR DESCRIPTION
The help text for the recently-added `--past-eof` option is the first I've heard of these useful `J`/`K` commands that've apparently been here all along :o

Apologies as I have little knowledge of this project's practices, but would like to help with this low-hanging fruit.