### PR TITLE
Exit with a failure status in more cases

### DIFF
--- a/edit.c
+++ b/edit.c
@@ -919,7 +919,7 @@ public int edit_stdin(void)
 	if (isatty(fd0))
 	{
 		error("Missing filename (\"less --help\" for help)", NULL_PARG);
-		quit(QUIT_OK);
+		quit(QUIT_ERROR);
 	}
 	return (edit("-"));
 }

--- a/main.c
+++ b/main.c
@@ -302,7 +302,7 @@ int main(int argc, constant char *argv[])
 		 * following string, but there was no following string.
 		 */
 		nopendopt();
-		quit(QUIT_OK);
+		quit(QUIT_ERROR);
 	}
 
 	if (is_tty)
@@ -373,13 +373,15 @@ int main(int argc, constant char *argv[])
 		 * Just copy the input file(s) to output.
 		 */
 		SET_BINARY(1);
-		if (edit_first() == 0)
-		{
-			set_output(1, TRUE); /* write to stdout */
-			do {
-				cat_file();
-			} while (edit_next(1) == 0);
-		}
+
+		if (edit_first())
+			quit(QUIT_ERROR);
+
+		set_output(1, TRUE); /* write to stdout */
+		do {
+			cat_file();
+		} while (edit_next(1) == 0);
+
 		quit(QUIT_OK);
 	}
 


### PR DESCRIPTION
The following conditions are fatal, yet less currently handles them by returning a success status. Return a failure status instead.

* Missing input filename when stdin is a terminal.

* Missing option argument (e.g. `less -b`).

* Not being able to open any input files in non-interactive mode (note that in interactive mode, this already returns a failure status).