### PR TITLE
Add a GitHub Actions workflow that tests less on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,61 @@
+name: Main
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  dist:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+
+    - name: Build distribution
+      id: build-dist
+      # Since we don't have a PGP key here, replace gpg with a no-op.
+      run: |
+        make -f Makefile.aut dist GPG=:
+        echo "basename=$(basename release/less-*)" > "$GITHUB_OUTPUT"
+
+    - uses: actions/upload-artifact@v7
+      with:
+        archive: false
+        path: release/${{ steps.build-dist.outputs.basename }}/${{ steps.build-dist.outputs.basename }}-beta.tar.gz
+
+    outputs:
+      basename: ${{ steps.build-dist.outputs.basename }}
+
+  linux:
+    runs-on: ubuntu-latest
+
+    needs: dist
+
+    steps:
+    - uses: actions/download-artifact@v8
+      with:
+        name: ${{ needs.dist.outputs.basename }}-beta.tar.gz
+
+    - name: Unpack
+      env:
+        BASENAME: ${{ needs.dist.outputs.basename }}
+      run: tar -xzf "$BASENAME-beta.tar.gz"
+
+    - name: Configure
+      working-directory: ${{ needs.dist.outputs.basename }}
+      run: ./configure
+
+    - name: Make
+      working-directory: ${{ needs.dist.outputs.basename }}
+      run: make LESSTEST=1
+
+    - name: Test
+      working-directory: ${{ needs.dist.outputs.basename }}
+      run: make check LESSTEST=1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,11 +24,12 @@ jobs:
       run: |
         make -f Makefile.aut dist GPG=:
         echo "basename=$(basename release/less-*)" > "$GITHUB_OUTPUT"
+        mv -v release/less-*/*.tar.gz less-githubtest.tar.gz
 
     - uses: actions/upload-artifact@v7
       with:
         archive: false
-        path: release/${{ steps.build-dist.outputs.basename }}/${{ steps.build-dist.outputs.basename }}-beta.tar.gz
+        path: less-githubtest.tar.gz
 
     outputs:
       basename: ${{ steps.build-dist.outputs.basename }}
@@ -41,12 +42,10 @@ jobs:
     steps:
     - uses: actions/download-artifact@v8
       with:
-        name: ${{ needs.dist.outputs.basename }}-beta.tar.gz
+        name: less-githubtest.tar.gz
 
     - name: Unpack
-      env:
-        BASENAME: ${{ needs.dist.outputs.basename }}
-      run: tar -xzf "$BASENAME-beta.tar.gz"
+      run: tar -xzf less-githubtest.tar.gz
 
     - name: Configure
       working-directory: ${{ needs.dist.outputs.basename }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,4 +66,4 @@ jobs:
 
     - name: Test
       working-directory: ${{ needs.dist.outputs.basename }}
-      run: make check LESSTEST=1
+      run: make check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,14 @@ jobs:
 
     - name: Make
       working-directory: ${{ needs.dist.outputs.basename }}
+      run: make
+
+    - name: Run sanity check
+      working-directory: ${{ needs.dist.outputs.basename }}
+      run: ./less README > README.out && cmp README README.out
+
+    - name: Make (LESSTEST)
+      working-directory: ${{ needs.dist.outputs.basename }}
       run: make LESSTEST=1
 
     - name: Test

--- a/Makefile.aut
+++ b/Makefile.aut
@@ -163,8 +163,7 @@ dist: ${DISTFILES}
 	echo "Creating $$RELDIR/$$TARF" && \
 	tar -cf - $$LESSREL | gzip -c >$$RELDIR/$$TARF && \
 	echo "Signing $$RELDIR/$$TARF" && \
-	${GPG} --detach-sign $$RELDIR/$$TARF && \
-	mv $$RELDIR/$$TARF.sig $$RELDIR/$$LESSREL.sig && \
+	${GPG} --detach-sign --output=$$RELDIR/$$LESSREL.sig $$RELDIR/$$TARF && \
 	echo "Creating $$RELDIR/$$ZIPF" && \
 	zip -rq $$RELDIR/$$ZIPF $$LESSREL && \
 	rm -rf $$LESSREL


### PR DESCRIPTION
I don't know if you'd be interested in something like this, but I thought it could be useful for testing incoming pull requests and commits.

If this is accepted, I'll try to send a followup PR to enable testing on Windows as well.
