### PR TITLE
Create single list of source files in Windows makefiles.

### DIFF
--- a/Makefile.wng
+++ b/Makefile.wng
@@ -109,36 +109,25 @@ LIBS += ${XLDLIBS}
 .c.o:
 	${CC} -c -I. ${CFLAGS} $<
 
-LESS_SRC = brac.c ch.c charset.c cmdbuf.c command.c		\
-           cvt.c decode.c edit.c evar.c filename.c forwback.c 		\
-           ifile.c input.c jump.c line.c linenum.c lmsg.c 		\
-           lsystem.c main.c mark.c optfunc.c option.c 		\
-	   opttbl.c os.c output.c pattern.c position.c 		\
-	   prompt.c          screen.c scrsize.c search.c 	\
-	   signal.c tags.c ttyin.c version.c xbuf.c
+LESS_SRC = brac.c ch.c charset.c cmdbuf.c command.c \
+           cvt.c decode.c edit.c evar.c filename.c forwback.c \
+           ifile.c input.c jump.c line.c linenum.c lmsg.c \
+           lsystem.c main.c mark.c optfunc.c option.c \
+           opttbl.c os.c output.c pattern.c position.c \
+           prompt.c screen.c search.c \
+           signal.c tags.c ttyin.c version.c xbuf.c
+
 ifeq  (${REGEX_PACKAGE},regcomp-local)
 LESS_SRC += regexp.c
 endif
+
 ifneq (${SECURE_COMPILE},1)
 LESS_SRC += lesskey_parse.c
-endif
-
-OBJ = \
-	main.o screen.o brac.o ch.o charset.o cmdbuf.o \
-	command.o cvt.o decode.o edit.o evar.o filename.o forwback.o \
-	help.o ifile.o input.o jump.o line.o linenum.o lmsg.o \
-	lsystem.o mark.o optfunc.o option.o opttbl.o os.o \
-	output.o pattern.o position.o prompt.o search.o signal.o \
-	tags.o ttyin.o version.o xbuf.o
-ifeq  (${REGEX_PACKAGE},regcomp-local)
-OBJ += regexp.o
-endif
-ifneq (${SECURE_COMPILE},1)
-OBJ += lesskey_parse.o
 else
 MINGW_DEFINES += -DSECURE_COMPILE=1
 endif
 
+OBJ = ${patsubst %.c,%.o,$(LESS_SRC)} help.o
 
 all: less.exe lessecho.exe
 

--- a/Makefile.wng
+++ b/Makefile.wng
@@ -25,8 +25,8 @@
 # REGEX_PACKAGE == gnu  (might not be available)
 #   This choice selects the GNU implementation, if provided by MingW.
 #
-# By default, the files help.c and funcs.h are generated using few posix
-# utilities (grep, sed, etc). On Windows, if the tools are missing, add:
+# By default, the files help.c, funcs.h and lessmsg.inc are generated using few
+# posix utilities (grep, sed, etc). On Windows, if the tools are missing, add:
 #   WINGEN=1
 # to compile a native C program which will be used instead of the posix tools.
 # NOTE: to cross compile with WINGEN=1, e.g. to arm, first run with native CC:

--- a/Makefile.wnm
+++ b/Makefile.wnm
@@ -63,7 +63,7 @@ defines.h: defines.wn
 
 $(OBJ): less.h funcs.h defines.h lang.h lmsg.h lessmsg.inc pattern.h xbuf.h
 
-# generate help.c and funcs.h.
+# generate help.c, funcs.h and lessmsg.inc.
 # intentionally detached from $(OBJ) in case of cross compile - needs native cc
 generated:
 	$(CC) buildgen.c

--- a/Makefile.wnm
+++ b/Makefile.wnm
@@ -30,21 +30,24 @@ LIBS = user32.lib shell32.lib
 
 #### End of system configuration section. ####
 
-OBJ1 = \
-	main.obj screen.obj brac.obj ch.obj charset.obj cmdbuf.obj \
-	command.obj cvt.obj decode.obj edit.obj evar.obj filename.obj forwback.obj \
-	help.obj ifile.obj input.obj jump.obj line.obj linenum.obj lmsg.obj \
-	lsystem.obj mark.obj optfunc.obj option.obj opttbl.obj os.obj \
-	output.obj pattern.obj position.obj prompt.obj search.obj signal.obj \
-	tags.obj ttyin.obj version.obj xbuf.obj regexp.obj
+SRC1 = brac.c ch.c charset.c cmdbuf.c command.c \
+       cvt.c decode.c edit.c evar.c filename.c forwback.c \
+       ifile.c input.c jump.c line.c linenum.c lmsg.c \
+       lsystem.c main.c mark.c optfunc.c option.c \
+       opttbl.c os.c output.c pattern.c position.c \
+       prompt.c screen.c search.c \
+       signal.c tags.c ttyin.c version.c xbuf.c \
+       regexp.c
 
 !IF "$(SECURE_COMPILE)" == "1"
-OBJ = $(OBJ1)
+SRC = $(SRC1)
 CFLAGS = $(CFLAGS1) /D "SECURE_COMPILE=1"
 !ELSE
-OBJ = $(OBJ1) lesskey_parse.obj
+SRC = $(SRC1) lesskey_parse.c
 CFLAGS = $(CFLAGS1)
 !ENDIF
+
+OBJ = $(patsubst %.c,%.obj,$(SRC)) help.obj
 
 # This rule allows us to supply the necessary -D options
 # in addition to whatever the user asks for.
@@ -62,12 +65,12 @@ defines.h: defines.wn
 
 $(OBJ): less.h funcs.h defines.h lang.h lmsg.h lessmsg.inc pattern.h xbuf.h
 
-# generate help.c and funcs.h. We use *.c because we don't have a sources list.
+# generate help.c and funcs.h.
 # intentionally detached from $(OBJ) in case of cross compile - needs native cc
 generated:
 	$(CC) buildgen.c
 	buildgen.exe help < less.hlp > help.c
-	type *.c 2>NUL | buildgen.exe funcs > funcs.h
+	type $(SRC) 2>NUL | buildgen.exe funcs > funcs.h
 	type lessmsg lessmsg_int 2>NUL | buildgen.exe lessmsg > lessmsg.inc
 
 clean:
@@ -76,4 +79,5 @@ clean:
 	-del defines.h
 	-del help.c
 	-del funcs.h
+	-del lessmsg.inc
 

--- a/Makefile.wnm
+++ b/Makefile.wnm
@@ -18,7 +18,7 @@
 CC = cl
 
 # Normal flags
-CFLAGS1 = /nologo /W3 /EHsc /O2 /I "." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /c
+CFLAGS = /nologo /W3 /EHsc /O2 /I "." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /c
 LDFLAGS = /nologo /subsystem:console /incremental:no
 
 # Debugging flags
@@ -30,24 +30,22 @@ LIBS = user32.lib shell32.lib
 
 #### End of system configuration section. ####
 
-SRC1 = brac.c ch.c charset.c cmdbuf.c command.c \
-       cvt.c decode.c edit.c evar.c filename.c forwback.c \
-       ifile.c input.c jump.c line.c linenum.c lmsg.c \
-       lsystem.c main.c mark.c optfunc.c option.c \
-       opttbl.c os.c output.c pattern.c position.c \
-       prompt.c screen.c search.c \
-       signal.c tags.c ttyin.c version.c xbuf.c \
-       regexp.c
+SRC = brac.c ch.c charset.c cmdbuf.c command.c \
+      cvt.c decode.c edit.c evar.c filename.c forwback.c \
+      ifile.c input.c jump.c line.c linenum.c lmsg.c \
+      lsystem.c main.c mark.c optfunc.c option.c \
+      opttbl.c os.c output.c pattern.c position.c \
+      prompt.c screen.c search.c \
+      signal.c tags.c ttyin.c version.c xbuf.c \
+      regexp.c
 
 !IF "$(SECURE_COMPILE)" == "1"
-SRC = $(SRC1)
-CFLAGS = $(CFLAGS1) /D "SECURE_COMPILE=1"
+CFLAGS = $(CFLAGS) /D "SECURE_COMPILE=1"
 !ELSE
-SRC = $(SRC1) lesskey_parse.c
-CFLAGS = $(CFLAGS1)
+SRC = $(SRC) lesskey_parse.c
 !ENDIF
 
-OBJ = $(patsubst %.c,%.obj,$(SRC)) help.obj
+OBJ = $(SRC:.c=.obj) help.obj
 
 # This rule allows us to supply the necessary -D options
 # in addition to whatever the user asks for.


### PR DESCRIPTION
Improve file handling in Makefile.wnm and Makefile.wng:

Makefile.wng previously contained two lists, LESS_SRC for source files and OBJ for object files. Unify these so that only LESS_SRC explicitly lists files. OBJ is derived from LESS_SRC using patsubst.

Makefile.wnm previously contained one list, OBJ of object files. Where the list of sources was needed, it just used "*.c". Change to make SRC a list of sources, and OBJ is derived from SRC using patsubst.