### PR TITLE
Add opt-in temporary-file spooling for standard input

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -293,7 +293,7 @@ AC_MSG_CHECKING(for ANSI function prototypes)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[int f(int a) { return a; }]])],[AC_MSG_RESULT(yes); AC_DEFINE(HAVE_ANSI_PROTOS)],[AC_MSG_RESULT(no)])
 
 # Checks for library functions.
-AC_CHECK_FUNCS([fchmod fsync nanosleep poll popen realpath _setjmp sigprocmask sigsetmask snprintf stat strsignal system ttyname usleep])
+AC_CHECK_FUNCS([fchmod fsync mkstemp nanosleep poll popen realpath _setjmp sigprocmask sigsetmask snprintf stat strsignal system ttyname usleep])
 AC_CHECK_DECL(sigsetjmp, [AC_DEFINE(HAVE_SIGSETJMP)], [], [#include <setjmp.h>])
 
 # AC_CHECK_FUNCS may not work for inline functions, so test these separately.

--- a/less.hlp
+++ b/less.hlp
@@ -286,6 +286,8 @@
                   Set default options for every search.
                 --show-preproc-errors
                   Display a message if preprocessor exits with an error status.
+                --spool-stdin
+                  Spool standard input to a temporary file before viewing it.
                 --past-eof
                   Scrolling commands continue past end of file.
                 --proc-backspace

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -2157,6 +2157,9 @@ If a LESSOPEN preprocessor produces data,
 then exits with a non-zero exit code,
 .B less
 will display a warning.
+.IP "\fB\-\-spool\-stdin\fP"
+When viewing standard input, copy it to a temporary file before displaying it.
+The temporary file is removed when \fBless\fP exits.
 .IP "\fB\-\-status\-col\-width=\fP\fIn\fP"
 Sets the width of the status column when the
 .B "\-J"

--- a/lessmsg
+++ b/lessmsg
@@ -331,6 +331,8 @@ Mouse_features Mouse features:\40
 Header_lines Header lines:\40
 Warn_when_editing_a_file_opened_via_LESSOPEN Warn when editing a file opened via LESSOPEN
 Dont_warn_when_editing_a_file_opened_via_LESSOPEN Don't warn when editing a file opened via LESSOPEN
+Dont_spool_standard_input Don't spool standard input to a temporary file
+Spool_standard_input Spool standard input to a temporary file
 interrupt_character interrupt character:\40
 Search_match_shift Search match shift:\40
 Autosave_actions Autosave actions:\40

--- a/main.c
+++ b/main.c
@@ -37,6 +37,7 @@ public POSITION start_attnpos = NULL_POSITION;
 public POSITION end_attnpos = NULL_POSITION;
 public int      wscroll;
 static constant char *progname;
+static char *stdin_spoolfile;
 public lbool    quitting = FALSE;
 public lbool    dohelp = FALSE;
 public char *   init_header = NULL;
@@ -74,11 +75,82 @@ extern lbool    missing_cap;
 extern int      know_dumb;
 extern int      quit_if_one_screen;
 extern int      no_init;
+extern int      spool_stdin;
 extern int      errmsgs;
 extern int      redraw_on_quit;
 extern int      term_addrs;
 extern lbool    first_time;
 extern lbool    term_init_ever;
+
+static void remove_stdin_spoolfile(void)
+{
+	if (stdin_spoolfile != NULL)
+	{
+		unlink(stdin_spoolfile);
+		free(stdin_spoolfile);
+	}
+}
+
+static char * make_stdin_spoolfile(void)
+{
+	constant char *tmpdir;
+	char *filename;
+	unsigned char buf[8192];
+	size_t len;
+	ssize_t n;
+	int fd;
+
+	tmpdir = lgetenv("TMPDIR");
+	if (isnullenv(tmpdir))
+		tmpdir = "/tmp";
+	len = strlen(tmpdir) + sizeof(PATHNAME_SEP) + sizeof("less-stdin-XXXXXX");
+	filename = (char *) ecalloc(len, sizeof(char));
+	SNPRINTF1(filename, len, "%s", tmpdir);
+	if (filename[strlen(filename)-1] != PATHNAME_SEP[0])
+		strcat(filename, PATHNAME_SEP);
+	strcat(filename, "less-stdin-XXXXXX");
+#if HAVE_MKSTEMP
+	fd = mkstemp(filename);
+#else
+	fd = -1;
+#endif
+	if (fd < 0)
+		goto error;
+	SET_BINARY(fd);
+	while ((n = read(0, buf, sizeof(buf))) > 0)
+	{
+		unsigned char *p = buf;
+		ssize_t remaining = n;
+		while (remaining > 0)
+		{
+			n = write(fd, p, (size_t) remaining);
+			if (n <= 0)
+			{
+				close(fd);
+				goto error;
+			}
+			p += n;
+			remaining -= n;
+		}
+	}
+	if (n < 0)
+	{
+		close(fd);
+		goto error;
+	}
+	close(fd);
+	return (filename);
+
+error:
+	{
+		PARG parg;
+		parg.p_string = filename;
+		error(LM(Cannot_write_to_X), &parg);
+	}
+	unlink(filename);
+	free(filename);
+	return (NULL);
+}
 
 #if MSDOS_COMPILER==WIN32C && (defined(__MINGW32__) || defined(_MSC_VER))
 /* malloc'ed 0-terminated utf8 of 0-terminated wide ws, or null on errors */
@@ -370,6 +442,16 @@ int main(int argc, constant char *argv[])
 #endif
 	}
 	xbuf_deinit(&xfiles);
+	if (spool_stdin && !dohelp && num_files == 0)
+	{
+		stdin_spoolfile = make_stdin_spoolfile();
+		if (stdin_spoolfile == NULL)
+			quit(QUIT_ERROR);
+		if (atexit(remove_stdin_spoolfile) != 0)
+			quit(QUIT_ERROR);
+		(void) get_ifile(stdin_spoolfile, ifile);
+		ifile = prev_ifile(NULL_IFILE);
+	}
 
 	/*
 	 * Set up terminal, etc.

--- a/opttbl.c
+++ b/opttbl.c
@@ -87,6 +87,7 @@ public int proc_return;         /* Special handling of carriage return */
 public int match_shift;         /* Extra horizontal shift on search match */
 public int no_paste;            /* Don't accept pasted input */
 public int no_edit_warn;        /* Don't warn when editing a LESSOPENed file */
+public int spool_stdin;         /* Spool standard input to a temporary file */
 public int stop_on_form_feed;   /* Stop scrolling on a line starting with form feed */
 public int past_eof;            /* Continue scrolling past EOF */
 public long match_shift_fraction = NUM_FRAC_DENOM/2; /* 1/2 of screen width */
@@ -179,6 +180,7 @@ static struct optname form_feed_optname = { "form-feed",         NULL };
 static struct optname past_eof_optname = { "past-eof",           NULL };
 static struct optname no_edit_warn_optname2 = { "no-warn-edit",   NULL };
 static struct optname no_edit_warn_optname = { "no-edit-warn",   &no_edit_warn_optname2 };
+static struct optname spool_stdin_optname = { "spool-stdin", NULL };
 static struct optname nonum_headers_optname = { "no-number-headers", NULL };
 static struct optname nosearch_headers_optname = { "no-search-headers", NULL };
 static struct optname nosearch_header_lines_optname = { "no-search-header-lines", NULL };
@@ -734,6 +736,15 @@ static struct loption option[] =
 		{
 			LM_Warn_when_editing_a_file_opened_via_LESSOPEN,
 			LM_Dont_warn_when_editing_a_file_opened_via_LESSOPEN,
+			LM_NULL
+		},
+		{ NULL, NULL, NULL }
+	},
+	{ OLETTER_NONE, &spool_stdin_optname,
+		O_BOOL, OPT_OFF, &spool_stdin, NULL,
+		{
+			LM_Dont_spool_standard_input,
+			LM_Spool_standard_input,
 			LM_NULL
 		},
 		{ NULL, NULL, NULL }


### PR DESCRIPTION
Many programs use less as their pager by piping generated output to standard
input. In that mode, less identifies the input as `-`, so the `v` command has
no editor-readable filename and reports "Cannot edit standard input".

This creates a downstream integration problem. Pager users get normal less
navigation and search, but tools which rely on `v` cannot offer an editor
handoff unless they implement their own temporary-file handling, change how
they invoke the pager, or disable that workflow. Those workarounds duplicate
temporary-file lifecycle, cleanup, quoting, and security handling outside less.

Add the opt-in `--spool-stdin` option. When less is invoked with
implicit standard input, it copies that input to a secure temporary file before
displaying it and opens the file normally. The existing `v` command therefore
works without a separate editor code path. The temporary file is removed when
less exits.

This is deliberately opt-in because it changes stdin handling: less must read
the complete input stream before it can display it, and it consumes temporary
disk space proportional to the input.

The option can also be supplied through `LESS`, for example:

```sh
some-command | LESS=--spool-stdin less
```

Validation:

- Prepared the git checkout with `make -f Makefile.aut all`.
- Full build succeeded.
- `make check` passed: 19 tests, 0 errors.
- A PTY smoke test piped `alpha\nbeta\n` into less, invoked `v`, verified that
  the editor received a `/tmp/less-stdin-*` path containing that exact input,
  and verified that the path was removed after less exited.
