### PR TITLE
Update documentation on lesskey paths & fix OS/2 lookup

### DIFF
--- a/decode.c
+++ b/decode.c
@@ -1459,17 +1459,29 @@ static int add_hometable(int (*call_lesskey)(constant char *, lbool), constant c
 		filename = save(def_filename);
 	else /* def_filename is just basename */
 	{
-		/* Remove first char (normally a dot) unless stored in $HOME. */
 		constant char *xdg = lgetenv("XDG_CONFIG_HOME");
 		if (!isnullenv(xdg))
+		/*
+		 * Remove the first character from the filename (either "." or "_"),
+		 * except on OS/2 which never has a leading character.
+		 */
+#if OS2
+			filename = dirfile(xdg, &def_filename, TRUE);
+#else
 			filename = dirfile(xdg, &def_filename[1], TRUE);
+#endif
 		if (filename == NULL)
 		{
 			constant char *home = lgetenv("HOME");
 			if (!isnullenv(home))
 			{
 				char *cfg_dir = dirfile(home, ".config", FALSE);
+				/* See earlier comment for rationale */
+#if OS2
+				filename = dirfile(cfg_dir, &def_filename, TRUE);
+#else
 				filename = dirfile(cfg_dir, &def_filename[1], TRUE);
+#endif
 				free(cfg_dir);
 			}
 		}

--- a/less.nro.VER
+++ b/less.nro.VER
@@ -2321,22 +2321,34 @@ If the environment variable LESSKEYIN is set,
 uses that as the name of the lesskey source file.
 Otherwise,
 .B less
-looks in a standard place for the lesskey source file:
-On Unix systems,
+checks several paths for the lesskey source file and uses the first it finds:
+.IP \(bu
+On Unix-like and OS-9 systems,
 .B less
-looks for a lesskey file called "$XDG_CONFIG_HOME/lesskey" or "$HOME/.config/lesskey" or "$HOME/.lesskey".
-On MS-DOS and Windows systems,
+looks for a lesskey file at "$XDG_CONFIG_HOME/lesskey" if the XDG_CONFIG_HOME
+environment variable is set, then "$HOME/.config/lesskey" and "$HOME/.lesskey".
+.IP \(bu
+On Windows systems,
 .B less
-looks for a lesskey file called "$HOME/_lesskey", and if it is not found there,
-then looks for a lesskey file called "_lesskey" in any directory specified
-in the PATH environment variable.
+looks for a lesskey file at "%XDG_CONFIG_HOME%\\lesskey" if the XDG_CONFIG_HOME
+environment variable is set, then "%HOME%\\.config\\lesskey" and
+"%HOME%\\_lesskey". If the HOME environment variable is unset (typical on
+Windows), it is derived from the concatenation of HOMEDRIVE and HOMEPATH.
+.IP \(bu
+On MS-DOS systems,
+.B less
+looks for a lesskey file at "%XDG_CONFIG_HOME%\\lesskey" if the XDG_CONFIG_HOME
+environment variable is set, then "%HOME%\\.config\\lesskey" and
+"%HOME%\\_lesskey". If none of these paths yield a lesskey file, every directory
+on the PATH is searched for a "_lesskey" file.
+.IP \(bu
 On OS/2 systems,
 .B less
-looks for a lesskey file called "$HOME/lesskey.ini", and if it is not found,
-then looks for a lesskey file called "lesskey.ini" in any directory specified
-in the INIT environment variable, and if it not found there,
-then looks for a lesskey file called "lesskey.ini" in any directory specified
-in the PATH environment variable.
+looks for a lesskey file at "%XDG_CONFIG_HOME%\\lesskey.ini" if the
+XDG_CONFIG_HOME environment variable is set, then
+"%HOME%\\.config\\lesskey.ini", "%HOME%\\lesskey.ini", and
+"%INIT%\\lesskey.ini". If none of these paths yield a lesskey file, every
+directory on the PATH is searched for a "lesskey.ini" file.
 .PP
 A system-wide lesskey source file may also be set up to provide key bindings.
 If a key is defined in both a local lesskey file and in the


### PR DESCRIPTION
The man page documentation on where `less` looks for a user's `lesskey` file is out of date for all systems except Unix-like. This PR documents the correct locations for Windows, MS-DOS, OS/2, and OS-9 systems and improves the presentation.

While updating the documentation I noticed a bug in the code when running on OS/2. `less` truncates the first character when looking under the `XDG_CONFIG_HOME` and `.config` paths in the user's home directory. That's correct where the default `lesskey` file has a leading `.` or `_`, but OS/2 is the exception as it uses `lesskey.ini`. The fix ensures on OS/2 that `lesskey.ini` is used with these paths instead of `esskey.ini`.

I'm not sure if OS/2 is in practice a supported platform anymore (or MS-DOS and OS-9 for that matter), but since the code and documentation are still present I've included them.

Note: Slightly larger diff is due to trimming unnecessary end-of-line whitespace in modified files.